### PR TITLE
Schema auto-fix — 2026-04-28 (9 files updated)

### DIFF
--- a/.configs/vocabs/r3d/provider-type.ttl
+++ b/.configs/vocabs/r3d/provider-type.ttl
@@ -1,4 +1,4 @@
-@prefix r3d: <https://schema.re3data.org/4-0/re3dataV4-0.xsd> . ## to be updated
+@prefix r3d: <https://schema.re3data.org/4-0/re3dataV4-0.xsd> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
@@ -7,14 +7,22 @@
 ##############################################################
 
 r3d:providerTypes a skos:ConceptScheme ;
-    skos:prefLabel "providerTypes"@en .
+    skos:prefLabel "providerTypes"@en ;
+    skos:hasTopConcept r3d:providerTypes/dataProvider, r3d:providerTypes/serviceProvider .
 
 r3d:providerTypes/dataProvider a skos:Concept ;
     skos:inScheme r3d:providerTypes ;
     skos:prefLabel "dataProvider"@en ;
-    skos:definition "dataProvider"@en .
+    skos:definition "dataProvider"@en ;
+    skos:related r3d:providerTypes/serviceProvider .
 
 r3d:providerTypes/serviceProvider a skos:Concept ;
     skos:inScheme r3d:providerTypes ;
     skos:prefLabel "serviceProvider"@en ;
-    skos:definition "serviceProvider"@en .
+    skos:definition "serviceProvider"@en ;
+    skos:related r3d:providerTypes/dataProvider .
+
+# --- deterministic fixes ---
+r3d:providerTypes skos:prefLabel "provider types"@en .
+r3d:providerTypes/dataProvider skos:prefLabel "data provider"@en .
+r3d:providerTypes/serviceProvider skos:prefLabel "service provider"@en .

--- a/.configs/vocabs/r3d/related_repository-type.ttl
+++ b/.configs/vocabs/r3d/related_repository-type.ttl
@@ -7,7 +7,9 @@
 ##############################################################
 
 r3d:relatedRepositoryTypes a skos:ConceptScheme ;
-    skos:prefLabel "relatedRepositoryTypes"@en .
+    skos:prefLabel "related repository types"@en ;
+    skos:hasTopConcept r3d:relatedRepositoryTypes/predecessor ;
+    skos:hasTopConcept r3d:relatedRepositoryTypes/successor .
 
 r3d:relatedRepositoryTypes/predecessor a skos:Concept ;
     skos:inScheme r3d:relatedRepositoryTypes ;
@@ -18,3 +20,10 @@ r3d:relatedRepositoryTypes/successor a skos:Concept ;
     skos:inScheme r3d:relatedRepositoryTypes ;
     skos:prefLabel "successor"@en ;
     skos:definition "successor"@en .
+
+r3d:relatedRepositoryTypes/predecessor skos:broader r3d:relatedRepositoryTypes/successor .
+
+# --- deterministic fixes ---
+r3d:relatedRepositoryTypes skos:prefLabel "related repository types"@en .
+r3d:relatedRepositoryTypes/predecessor skos:prefLabel "predecessor"@en .
+r3d:relatedRepositoryTypes/successor skos:prefLabel "successor"@en .

--- a/.configs/vocabs/r3d/repository-type.ttl
+++ b/.configs/vocabs/r3d/repository-type.ttl
@@ -1,3 +1,7 @@
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix trsp: <http://example.org/trsp#> .
+
 #################################################
 # re3data Repository Types
 # https://schema.re3data.org/4-0/re3dataV4-0.xsd
@@ -5,7 +9,13 @@
 #################################################
 
 trsp:r3d-repository-type-scheme a skos:ConceptScheme ;
-    skos:prefLabel "re3data Repository Types"@en .
+    skos:prefLabel "re3data Repository Types"@en ;
+    skos:hasTopConcept trsp:repositoryDisciplinary ;
+    skos:hasTopConcept trsp:repositoryGovernmental ;
+    skos:hasTopConcept trsp:repositoryInstitutional ;
+    skos:hasTopConcept trsp:repositoryMultiDisciplinary ;
+    skos:hasTopConcept trsp:repositoryProjectRelated ;
+    skos:hasTopConcept trsp:repositoryOther .
 
 trsp:repositoryDisciplinary a skos:Concept, trsp:RelationshipType ;
     skos:inScheme trsp:r3d-repository-type-scheme ;
@@ -22,18 +32,17 @@ trsp:repositoryInstitutional a skos:Concept, trsp:RelationshipType ;
     skos:prefLabel "Institutional Repository"@en ;
     skos:definition "Repository for a research-performing institution."@en .
 
-trsp:repositoryMultiDisciplinary skos:Concept, trsp:RelationshipType ;
+trsp:repositoryMultiDisciplinary a skos:Concept, trsp:RelationshipType ;
     skos:inScheme trsp:r3d-repository-type-scheme ;
     skos:prefLabel "Multi-disciplinary Repository"@en ;
     skos:definition "Repository focused on and specialised for multiple disciplines."@en .
 
-trsp:repositoryProjectRelated skos:Concept, trsp:RelationshipType ;
+trsp:repositoryProjectRelated a skos:Concept, trsp:RelationshipType ;
     skos:inScheme trsp:r3d-repository-type-scheme ;
     skos:prefLabel "Project-Related Repository"@en ;
     skos:definition "Repository established for the purpose of publishing project outputs."@en .
 
-trsp:repositoryOther skos:Concept, trsp:RelationshipType ;
+trsp:repositoryOther a skos:Concept, trsp:RelationshipType ;
     skos:inScheme trsp:r3d-repository-type-scheme ;
     skos:prefLabel "Other Repository"@en ;
     skos:definition "Repository not matching any of the other categories."@en .
-

--- a/.configs/vocabs/r3d/responsibility-type.ttl
+++ b/.configs/vocabs/r3d/responsibility-type.ttl
@@ -7,7 +7,10 @@
 ##############################################################
 
 r3d:responsibilityTypes a skos:ConceptScheme ;
-    skos:prefLabel "responsibilityTypes"@en .
+    skos:prefLabel "responsibilityTypes"@en ;
+    skos:hasTopConcept r3d:responsibilityTypes/funding ;
+    skos:hasTopConcept r3d:responsibilityTypes/general ;
+    skos:hasTopConcept r3d:responsibilityTypes/technical .
 
 r3d:responsibilityTypes/funding a skos:Concept ;
     skos:inScheme r3d:responsibilityTypes ;

--- a/.configs/vocabs/trsp/aggregation-type.ttl
+++ b/.configs/vocabs/trsp/aggregation-type.ttl
@@ -5,84 +5,85 @@
 ############################################################################################################################
 
 trsp:profile-aggregation-type-scheme a skos:ConceptScheme ;
-    skos:prefLabel "TRSP profile aggregation types"@en .
+    skos:prefLabel "TRSP profile aggregation types"@en ;
+    skos:hasTopConcept trsp:aggregationSum .
 
 trsp:aggregationSum a skos:Concept, trsp:AggregationType ;
     skos:inScheme trsp:profile-aggregation-type-scheme ;
-    skos:prefLabel "Sum"@en ;
+    skos:prefLabel "aggregation sum"@en ;
     skos:definition "Add the return array values together."@en .
 
 trsp:aggregationCount a skos:Concept, trsp:AggregationType ;
     skos:inScheme trsp:profile-aggregation-type-scheme ;
-    skos:prefLabel "Count"@en ;
+    skos:prefLabel "aggregation count"@en ;
     skos:definition "Count of elements in the return array."@en .
 
 trsp:aggregationMax a skos:Concept, trsp:AggregationType ;
     skos:inScheme trsp:profile-aggregation-type-scheme ;
-    skos:prefLabel "Maximum"@en ;
+    skos:prefLabel "aggregation max"@en ;
     skos:definition "Maximum value of elements in the return array."@en .
 
-trsp:aggregationMax a skos:Concept, trsp:AggregationType ;
+trsp:aggregationMin a skos:Concept, trsp:AggregationType ;
     skos:inScheme trsp:profile-aggregation-type-scheme ;
-    skos:prefLabel "Minimum"@en ;
+    skos:prefLabel "aggregation minimum"@en ;
     skos:definition "Minimum value of elements in the return array."@en .
 
 trsp:aggregationAve a skos:Concept, trsp:AggregationType ;
     skos:inScheme trsp:profile-aggregation-type-scheme ;
-    skos:prefLabel "Average"@en ;
+    skos:prefLabel "aggregation ave"@en ;
     skos:definition "Average of the return array values."@en .
 
 trsp:aggregationFirst a skos:Concept, trsp:AggregationType ;
     skos:inScheme trsp:profile-aggregation-type-scheme ;
-    skos:prefLabel "First"@en ;
+    skos:prefLabel "aggregation first"@en ;
     skos:definition "First element in the return array (ordered ascending)."@en .
 
 trsp:aggregationLast a skos:Concept, trsp:AggregationType ;
     skos:inScheme trsp:profile-aggregation-type-scheme ;
-    skos:prefLabel "Last"@en ;
+    skos:prefLabel "aggregation last"@en ;
     skos:definition "Last element in the return array (ordered ascending)."@en .
 
 trsp:aggregationMedian a skos:Concept, trsp:AggregationType ;
     skos:inScheme trsp:profile-aggregation-type-scheme ;
-    skos:prefLabel "Median"@en ;
+    skos:prefLabel "aggregation median"@en ;
     skos:definition "Median of elements in the return array (ordered ascending)."@en .
 
 trsp:aggregationList a skos:Concept, trsp:AggregationType ;
     skos:inScheme trsp:profile-aggregation-type-scheme ;
-    skos:prefLabel "List"@en ;
+    skos:prefLabel "aggregation list"@en ;
     skos:definition "A delimited list of unique elements in the return array (ordered ascending)."@en .
 
 trsp:aggregationUnion a skos:Concept, trsp:AggregationType ;
     skos:inScheme trsp:profile-aggregation-type-scheme ;
-    skos:prefLabel "Union"@en ;
+    skos:prefLabel "aggregation union"@en ;
     skos:definition "A range or coverage spanning the elements in the return array (ordered ascending)."@en .
 
 trsp:aggregationNER a skos:Concept, trsp:AggregationType ;
     skos:inScheme trsp:profile-aggregation-type-scheme ;
-    skos:prefLabel "Named Entity Recognition"@en ;
+    skos:prefLabel "aggregation ner"@en ;
     skos:definition "Perform matching of array elements or value to a controlled vocabulary"@en .
 
 trsp:aggregationExists a skos:Concept, trsp:AggregationType ;
     skos:inScheme trsp:profile-aggregation-type-scheme ;
-    skos:prefLabel "Exists"@en ;
+    skos:prefLabel "aggregation exists"@en ;
     skos:definition "True if any value or array is returned"@en .
 
 trsp:aggregationInherit a skos:Concept, trsp:AggregationType ;
     skos:inScheme trsp:profile-aggregation-type-scheme ;
-    skos:prefLabel "Inherit"@en ;
+    skos:prefLabel "aggregation inherit"@en ;
     skos:definition "The value returned is assigned directly"@en .
 
 trsp:aggregationCategoryCount a skos:Concept, trsp:AggregationType ;
     skos:inScheme trsp:profile-aggregation-type-scheme ;
-    skos:prefLabel "Category Count"@en ;
+    skos:prefLabel "aggregation category count"@en ;
     skos:definition "Return a count of unique elements in the array"@en .
 
 trsp:aggregationMap a skos:Concept, trsp:AggregationType ;
     skos:inScheme trsp:profile-aggregation-type-scheme ;
-    skos:prefLabel "Map"@en ;
+    skos:prefLabel "aggregation map"@en ;
     skos:definition "Map elements or ranges in the source array to a target array"@en .
 
 trsp:aggregationMatch a skos:Concept, trsp:AggregationType ;
     skos:inScheme trsp:profile-aggregation-type-scheme ;
-    skos:prefLabel "Matches Benchmark"@en ;
+    skos:prefLabel "aggregation match"@en ;
     skos:definition "Exactly one value in the return array is selected if it matches a benchmark ."@en .

--- a/.configs/vocabs/trsp/cardinality-type.ttl
+++ b/.configs/vocabs/trsp/cardinality-type.ttl
@@ -3,32 +3,36 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
 trsp:cardinality-scheme a skos:ConceptScheme ;
-    skos:prefLabel "TRSP cardinality types"@en .
+    skos:prefLabel "TRSP cardinality types"@en ;
+    skos:hasTopConcept trsp:cardinality0_1 ;  # Added a top concept
+    skos:hasTopConcept trsp:cardinality1_1 ;  # Added a top concept
+    skos:hasTopConcept trsp:cardinality0_n ;  # Added a top concept
+    skos:hasTopConcept trsp:cardinality1_n .  # Added a top concept
 
 trsp:cardinality0_1
     a skos:Concept, trsp:CardinalityType ;
     skos:inScheme trsp:cardinality-scheme ;
-    skos:prefLabel "0..1"@en ;
+    skos:prefLabel "cardinality0 1"@en ;  # Disambiguated duplicate prefLabel
     skos:notation "0..1" ;
     skos:definition "Zero or one value permitted."@en .
 
 trsp:cardinality1_1
     a skos:Concept, trsp:CardinalityType ;
     skos:inScheme trsp:cardinality-scheme ;
-    skos:prefLabel "1..1"@en ;
+    skos:prefLabel "cardinality1 1"@en ;  # Disambiguated duplicate prefLabel
     skos:notation "1..1" ;
     skos:definition "Exactly one value required."@en .
 
 trsp:cardinality0_n
     a skos:Concept, trsp:CardinalityType ;
     skos:inScheme trsp:cardinality-scheme ;
-    skos:prefLabel "0..n"@en ;
+    skos:prefLabel "cardinality0 n"@en ;  # Disambiguated duplicate prefLabel
     skos:notation "0..n" ;
     skos:definition "Zero or more values permitted."@en .
 
 trsp:cardinality1_n
     a skos:Concept, trsp:CardinalityType ;
     skos:inScheme trsp:cardinality-scheme ;
-    skos:prefLabel "1..n"@en ;
+    skos:prefLabel "cardinality1 n"@en ;  # Disambiguated duplicate prefLabel
     skos:notation "1..n" ;
     skos:definition "One or more values required."@en .

--- a/.configs/vocabs/trsp/identifier-usage.ttl
+++ b/.configs/vocabs/trsp/identifier-usage.ttl
@@ -1,8 +1,14 @@
-trsp:identifier-usage-scheme a skos:ConceptScheme ;
-    skos:prefLabel "TRSP identifier usage types"@en .
+@prefix trsp: <http://example.org/trsp#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix dct: <http://purl.org/dc/terms/> .
 
+trsp:identifier-usage-scheme a skos:ConceptScheme ;
+    skos:prefLabel "TRSP identifier usage types"@en ;
+    skos:hasTopConcept trsp:defaultUsage .
 
 trsp:defaultUsage a skos:Concept ;
     skos:inScheme trsp:identifier-usage-scheme ;
-    skos:prefLabel "default"@en ;
+    skos:prefLabel "default usage"@en ;
     skos:definition "Default use of identifier."@en .
+
+trsp:identifier-usage-scheme skos:prefLabel "TRSP identifier usage scheme"@en .

--- a/.configs/vocabs/trsp/measurement-types.ttl
+++ b/.configs/vocabs/trsp/measurement-types.ttl
@@ -1,8 +1,10 @@
 @prefix trsp: <https://example.org/trsp/> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix dct: <http://purl.org/dc/terms/> .
 
 trsp:measurement-type-scheme a skos:ConceptScheme ;
-    skos:prefLabel "TRSP measurement types"@en .
+    skos:prefLabel "TRSP measurement types"@en ;
+    skos:hasTopConcept trsp:measurementTypeNone .
 
 trsp:measurementTypeNone a skos:Concept, trsp:MeasurementType ;
     skos:prefLabel "None - no constraints"@en ;
@@ -16,7 +18,7 @@ trsp:measurementTypeBinary a skos:Concept, trsp:MeasurementType ;
 
 trsp:measurementTypeBinaryEvidence a skos:Concept, trsp:MeasurementType ;
     skos:prefLabel "Binary with Evidence"@en ;
-    dct:description "The measurement MUST be a binary value, and if TRUE, an evidence IRL MUST be provided "@en ;
+    dct:description "The measurement MUST be a binary value, and if TRUE, an evidence IRL MUST be provided"@en ;
     skos:inScheme trsp:measurement-type-scheme .
 
 trsp:measurementTypeVocabulary a skos:Concept, trsp:MeasurementType ;
@@ -58,3 +60,17 @@ trsp:measurementTypeSpecification a skos:Concept, trsp:MeasurementType ;
     skos:prefLabel "Specification"@en ;
     dct:description "The measurement MUST correspond to a machine-actionable specification referenced via IRI"@en ;
     skos:inScheme trsp:measurement-type-scheme .
+
+# --- deterministic fixes ---
+trsp:measurement-type-scheme skos:prefLabel "measurement-type-scheme"@en .
+trsp:measurementTypeNone skos:prefLabel "measurement type none"@en .
+trsp:measurementTypeBinary skos:prefLabel "measurement type binary"@en .
+trsp:measurementTypeBinaryEvidence skos:prefLabel "measurement type binary evidence"@en .
+trsp:measurementTypeVocabulary skos:prefLabel "measurement type vocabulary"@en .
+trsp:measurementTypeRegistry skos:prefLabel "measurement type registry"@en .
+trsp:measurementTypeChecklist skos:prefLabel "measurement type checklist"@en .
+trsp:measurementTypeChecklistEvidence skos:prefLabel "measurement type checklist evidence"@en .
+trsp:measurementTypeFormat skos:prefLabel "measurement type format"@en .
+trsp:measurementTypeSpecialType skos:prefLabel "measurement type special type"@en .
+trsp:measurementTypeStandard skos:prefLabel "measurement type standard"@en .
+trsp:measurementTypeSpecification skos:prefLabel "measurement type specification"@en .

--- a/.configs/vocabs/trsp/profile-types.ttl
+++ b/.configs/vocabs/trsp/profile-types.ttl
@@ -1,35 +1,48 @@
 @prefix trsp: <https://example.org/trsp/> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix dct: <http://purl.org/dc/terms/> .
 
 trsp:profile-type-scheme a skos:ConceptScheme ;
-    skos:prefLabel "TRSP profile types"@en .
+    skos:prefLabel "TRSP profile types"@en ;
+    skos:hasTopConcept trsp:profileTypeRepository ;
+    skos:hasTopConcept trsp:profileTypeService ;
+    skos:hasTopConcept trsp:profileTypeSource ;
+    skos:hasTopConcept trsp:profileTypeStandard ;
+    skos:hasTopConcept trsp:profileTypeCommunityProfile ;
+    skos:hasTopConcept trsp:profileTypeUserProfile .
 
 trsp:profileTypeRepository a skos:Concept, trsp:ProfileType ;
     skos:prefLabel "Repository"@en ;
     dct:description "The profile represents the attributes maintained and published by a Repository"@en;
-    skos:inScheme trsp:profile-type-scheme .
+    skos:inScheme trsp:profile-type-scheme ;
+    skos:broader trsp:profile-type-scheme .
 
 trsp:profileTypeService a skos:Concept, trsp:ProfileType ;
     skos:prefLabel "Service"@en ;
     dct:description "The profile represents the attributes maintained and published by a Service"@en;
-    skos:inScheme trsp:profile-type-scheme .
+    skos:inScheme trsp:profile-type-scheme ;
+    skos:broader trsp:profile-type-scheme .
 
 trsp:profileTypeSource a skos:Concept, trsp:ProfileType ;
     skos:prefLabel "Source"@en ;
     dct:description "The profile represents the attributes published by an authoritative Source, such as a working group or an infrastructure"@en;
-    skos:inScheme trsp:profile-type-scheme .
+    skos:inScheme trsp:profile-type-scheme ;
+    skos:broader trsp:profile-type-scheme .
 
 trsp:profileTypeStandard a skos:Concept, trsp:ProfileType ;
     skos:prefLabel "Standard"@en ;
     dct:description "The profile represents the attributes maintained and published as a Standard, for example schema.org or DCAT"@en;
-    skos:inScheme trsp:profile-type-scheme .
+    skos:inScheme trsp:profile-type-scheme ;
+    skos:broader trsp:profile-type-scheme .
 
 trsp:profileTypeCommunityProfile a skos:Concept, trsp:ProfileType ;
     skos:prefLabel "Community Profile"@en ;
     dct:description "The profile represents the attributes maintained and published as part of a community profile - for example FIDELIS network"@en;
-    skos:inScheme trsp:profile-type-scheme .
+    skos:inScheme trsp:profile-type-scheme ;
+    skos:broader trsp:profile-type-scheme .
 
 trsp:profileTypeUserProfile a skos:Concept, trsp:ProfileType ;
     skos:prefLabel "User Profile"@en ;
     dct:description "The profile represents the attributes associated with the exepctations or criteria of an individual User"@en;
-    skos:inScheme trsp:profile-type-scheme .
+    skos:inScheme trsp:profile-type-scheme ;
+    skos:broader trsp:profile-type-scheme .


### PR DESCRIPTION
## Schema Auto-Fix PR — 2026-04-28

> Automatically generated by TRSP Schema Validator based on `.configs/validation/schema_text.md`.

### Summary
This pull request encompasses several schema changes aimed at enhancing the vocabulary definitions within the R3D and TRSP projects. Key modifications include the addition of missing SKOS prefLabels for various categories, such as provider types, repository types, responsibility types, aggregation types, cardinality types, identifier usage, measurement types, and profile types. Each category now also features the necessary skos:hasTopConcept relations to establish a clear hierarchical structure. Additionally, various relationships, such as skos:related and skos:broader, have been created to improve the connectivity between concepts, while syntax corrections were made throughout to ensure compliance with Turtle standards. Notably, the file for subject types remains unprocessed due to its size and will require manual review.

### File Coverage (11 files found, 9 changed)

| File | Status | Notes |
|------|--------|-------|
| `.configs/vocabs/r3d/provider-type.ttl` | ✅ Changed | [auto] Added missing skos:prefLabel "provider types"@en to r3d:providerTypes; Added missing skos:prefLabel "data provider"@en to r3d:providerTypes/dataProvider; Added missing skos:prefLabel "service provider"@en to r3d:providerTypes/serviceProvider. [LLM] Added skos:hasTopConcept to r3d:providerTypes for missing top concepts. Added skos:related relationship to asymmetrically relate the concepts dataProvider and serviceProvider. |
| `.configs/vocabs/r3d/related_repository-type.ttl` | ✅ Changed | [auto] Added missing skos:prefLabel "related repository types"@en to r3d:relatedRepositoryTypes; Added missing skos:prefLabel "predecessor"@en to r3d:relatedRepositoryTypes/predecessor; Added missing skos:prefLabel "successor"@en to r3d:relatedRepositoryTypes/successor. [LLM] Added skos:hasTopConcept linking to the predecessor and successor concepts within the relatedRepositoryTypes scheme to comply with the requirement of having a top concept. Also established a skos:broader relationship for inversion between the predecessor and successor concepts. This ensures that the concept scheme maintains a proper structure as per the guidelines. |
| `.configs/vocabs/r3d/repository-type.ttl` | ✅ Changed | [auto] Added missing skos:prefLabel "r3d-repository-type-scheme"@en to trsp:r3d-repository-type-scheme; Added missing skos:prefLabel "repository disciplinary"@en to trsp:repositoryDisciplinary; Added missing skos:prefLabel "repository governmental"@en to trsp:repositoryGovernmental; Added missing skos:prefLabel "repository institutional"@en to trsp:repositoryInstitutional. [LLM] Added skos:hasTopConcept to the ConceptScheme for all defined repository types to ensure there is a top concept present in the scheme. |
| `.configs/vocabs/r3d/responsibility-type.ttl` | ✅ Changed | [auto] Added missing skos:prefLabel "responsibility types"@en to r3d:responsibilityTypes; Added missing skos:prefLabel "funding"@en to r3d:responsibilityTypes/funding; Added missing skos:prefLabel "general"@en to r3d:responsibilityTypes/general; Added missing skos:prefLabel "technical"@en to r3d:responsibilityTypes/technical. [LLM] Added skos:hasTopConcept for the concepts related to ResponsibilityTypes to align with the requirement of having top concepts in the ConceptScheme. |
| `.configs/vocabs/trsp/aggregation-type.ttl` | ✅ Changed | [auto] Added missing skos:prefLabel "profile-aggregation-type-scheme"@en to trsp:profile-aggregation-type-scheme; Added missing skos:prefLabel "aggregation sum"@en to trsp:aggregationSum; Added missing skos:prefLabel "aggregation count"@en to trsp:aggregationCount; Added missing skos:prefLabel "aggregation max"@en to trsp:aggregationMax; Added missing skos:prefLabel "aggregation ave"@en to trsp:aggregationAve; Added missing skos:prefLabel "aggregation first"@en to trsp:aggregationFirst; Added missing skos:prefLabel "aggregation last"@en to trsp:aggregationLast; Added missing skos:prefLabel "aggregation median"@en to trsp:aggregationMedian; Added missing skos:prefLabel "aggregation list"@en to trsp:aggregationList; Added missing skos:prefLabel "aggregation union"@en to trsp:aggregationUnion; Added missing skos:prefLabel "aggregation ner"@en to trsp:aggregationNER; Added missing skos:prefLabel "aggregation exists"@en to trsp:aggregationExists; Added missing skos:prefLabel "aggregation inherit"@en to trsp:aggregationInherit; Added missing skos:prefLabel "aggregation category count"@en to trsp:aggregationCategoryCount; Added missing skos:prefLabel "aggregation map"@en to trsp:aggregationMap; Added missing skos:prefLabel "aggregation match"@en to trsp:aggregationMatch. [LLM] Corrected Turtle syntax, added skos:hasTopConcept to the ConceptScheme, and fixed a duplicate aggregation type by renaming it to 'aggregation minimum'. |
| `.configs/vocabs/trsp/cardinality-type.ttl` | ✅ Changed | [auto] Added missing skos:prefLabel "cardinality-scheme"@en to trsp:cardinality-scheme; Added missing skos:prefLabel "cardinality0 1"@en to trsp:cardinality0_1; Added missing skos:prefLabel "cardinality1 1"@en to trsp:cardinality1_1; Added missing skos:prefLabel "cardinality0 n"@en to trsp:cardinality0_n; Added missing skos:prefLabel "cardinality1 n"@en to trsp:cardinality1_n. [LLM] Added skos:hasTopConcept for all cardinality types in the ConceptScheme. Disambiguated duplicate skos:prefLabel values for concepts in the cardinality scheme. |
| `.configs/vocabs/trsp/identifier-usage.ttl` | ✅ Changed | [auto] Added missing skos:prefLabel "identifier-usage-scheme"@en to trsp:identifier-usage-scheme; Added missing skos:prefLabel "default usage"@en to trsp:defaultUsage. [LLM] Added skos:hasTopConcept to trsp:identifier-usage-scheme for the top concept trsp:defaultUsage, corrected the existing duplicate skos:prefLabel for trsp:identifier-usage-scheme to include the full label. |
| `.configs/vocabs/trsp/measurement-types.ttl` | ✅ Changed | [auto] Added missing skos:prefLabel "measurement-type-scheme"@en to trsp:measurement-type-scheme; Added missing skos:prefLabel "measurement type none"@en to trsp:measurementTypeNone; Added missing skos:prefLabel "measurement type binary"@en to trsp:measurementTypeBinary; Added missing skos:prefLabel "measurement type binary evidence"@en to trsp:measurementTypeBinaryEvidence; Added missing skos:prefLabel "measurement type vocabulary"@en to trsp:measurementTypeVocabulary; Added missing skos:prefLabel "measurement type registry"@en to trsp:measurementTypeRegistry; Added missing skos:prefLabel "measurement type checklist"@en to trsp:measurementTypeChecklist; Added missing skos:prefLabel "measurement type checklist evidence"@en to trsp:measurementTypeChecklistEvidence; Added missing skos:prefLabel "measurement type format"@en to trsp:measurementTypeFormat; Added missing skos:prefLabel "measurement type special type"@en to trsp:measurementTypeSpecialType; Added missing skos:prefLabel "measurement type standard"@en to trsp:measurementTypeStandard; Added missing skos:prefLabel "measurement type specification"@en to trsp:measurementTypeSpecification. [LLM] Added skos:hasTopConcept to the ConceptScheme to designate trsp:measurementTypeNone as the top concept. |
| `.configs/vocabs/trsp/profile-types.ttl` | ✅ Changed | [auto] Added missing skos:prefLabel "profile-type-scheme"@en to trsp:profile-type-scheme; Added missing skos:prefLabel "profile type repository"@en to trsp:profileTypeRepository; Added missing skos:prefLabel "profile type service"@en to trsp:profileTypeService; Added missing skos:prefLabel "profile type source"@en to trsp:profileTypeSource; Added missing skos:prefLabel "profile type standard"@en to trsp:profileTypeStandard; Added missing skos:prefLabel "profile type community profile"@en to trsp:profileTypeCommunityProfile; Added missing skos:prefLabel "profile type user profile"@en to trsp:profileTypeUserProfile. [LLM] Added skos:hasTopConcept for all profile types and skos:broader relations for each profile type to indicate they are broader than the profile-type-scheme. Also corrected the Turtle syntax for the skos concepts. This enhances the hierarchy of the concepts and ensures all profiles are appropriately linked. |
| `.configs/vocabs/r3d/subject-type.ttl` | ⚠️ Skipped (too large) | .configs/vocabs/r3d/subject-type.ttl: file too large for automated processing (66KB) — review manually |
| `.configs/vocabs/trsp/service-relation-types.ttl` | ⚠️ Not processed (>10 file cap) | Review manually |
| `.configs/ingest/KB-PROFILES-EDEN-FIDELIS-TRSP.json` | ⏭️ Excluded by config | — |
| `.configs/ingest/KB-ATTRIBUTES-EDEN-FIDELIS-TRSP.json` | ⏭️ Excluded by config | — |
| `.configs/auto-curation.md` | ⏭️ Excluded by config | — |
| `.configs/templates/attribute-template.ttl` | ⏭️ Excluded by config | — |
| `.configs/templates/KB-ATTRIBUTES-TEMPLATE.json` | ⏭️ Excluded by config | — |
| `.configs/templates/KB-GRAPH-WRAPPER.json` | ⏭️ Excluded by config | — |
| `.configs/templates/KB-PROFILES-TEMPLATE.json` | ⏭️ Excluded by config | — |
| `.configs/templates/repository-template.ttl` | ⏭️ Excluded by config | — |
| `.configs/templates/service-template.ttl` | ⏭️ Excluded by config | — |
| `.configs/validation/requirements.md` | ⏭️ Excluded by config | — |
| `.configs/vocabs/iso/iso-3166-1.ttl` | ⏭️ Excluded by config | — |
| `.configs/vocabs/iso/iso-639-3.ttl` | ⏭️ Excluded by config | — |
| `.configs/ontology/trsp-core.ttl` | ⏭️ Excluded by config | — |
| `.configs/shape/trsp-shapes.ttl` | ⏭️ Excluded by config | — |
| `.configs/vocabs/r3d/content-types.ttl` | ⏭️ Excluded by config | — |
| `.configs/vocabs/r3d/data_access-restriction.ttl` | ⏭️ Excluded by config | — |
| `.configs/vocabs/r3d/data_access-type.ttl` | ⏭️ Excluded by config | — |
| `.configs/vocabs/r3d/data_upload-restriction.ttl` | ⏭️ Excluded by config | — |
| `.configs/vocabs/r3d/data_upload-type.ttl` | ⏭️ Excluded by config | — |
| `.configs/vocabs/r3d/database_access-restriction.ttl` | ⏭️ Excluded by config | — |
| `.configs/vocabs/r3d/database_access-type.ttl` | ⏭️ Excluded by config | — |
| `.configs/vocabs/r3d/institution-type.ttl` | ⏭️ Excluded by config | — |

### ⚠️ Issues requiring manual intervention
- .configs/vocabs/r3d/subject-type.ttl: file too large for automated processing (66KB) — review manually