### PR TITLE
Schema extraction: .configs/ingest/graph/registry.trig — 2026-04-29

### DIFF
--- a/.configs/ingest/graph/schema_analysis.ttl
+++ b/.configs/ingest/graph/schema_analysis.ttl
@@ -1,5 +1,5 @@
 # Schema extraction from: .configs/ingest/graph/registry.trig
-# Generated: 2026-04-29T10:01:03.712Z
+# Generated: 2026-04-29T10:09:45.282Z
 
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .

--- a/.configs/ingest/graph/schema_analysis_summary.ttl
+++ b/.configs/ingest/graph/schema_analysis_summary.ttl
@@ -1,0 +1,57 @@
+# Consolidated schema summary from: .configs/ingest/graph/registry.trig
+# All named graphs aggregated — unique type → property list
+# Generated: 2026-04-29T10:09:45.296Z
+
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix ex: <https://trsp.example/schema-extract#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix schema: <http://schema.org/> .
+@prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
+
+ex:summary_ex_DepositionPolicy a ex:TypeSummary ;
+  ex:nodeType <ex:DepositionPolicy> ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+.
+
+ex:summary_Policy a ex:TypeSummary ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:publisher ;
+.
+
+ex:summary_Catalog a ex:TypeSummary ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty vcard:url ;
+  ex:usesProperty dcat:service ;
+.
+
+ex:summary_CatalogRecord a ex:TypeSummary ;
+  ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:wasAssociatedWith ;
+  ex:usesProperty prov:wasGeneratedBy ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:summary_Project a ex:TypeSummary ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty vcard:url ;
+  ex:usesProperty dcat:service ;
+.


### PR DESCRIPTION
## Schema Extraction — .configs/ingest/graph/registry.trig

> Automatically extracted by TRSP Schema Extraction on 2026-04-29.

### Summary
- **Named graphs analysed**: 321
- **Node types found**: 704
- **Unique property usages**: 2243
- **Unique types (consolidated)**: 5

### Output files
- `.configs/ingest/graph/schema_analysis.ttl` — per-graph detail (TTL)
- `.configs/ingest/graph/schema_analysis_summary.ttl` — consolidated type→property summary (TTL)