### PR TITLE
Schema extraction: .configs/ingest/graph/registry.trig — 2026-04-29

### DIFF
--- a/.configs/ingest/graph/schema_analysis.ttl
+++ b/.configs/ingest/graph/schema_analysis.ttl
@@ -1,5 +1,5 @@
 # Schema extraction from: .configs/ingest/graph/registry.trig
-# Generated: 2026-04-29T11:33:15.173Z
+# Generated: 2026-04-29T11:38:35.084Z
 
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .

--- a/.configs/ingest/graph/schema_analysis_summary.ttl
+++ b/.configs/ingest/graph/schema_analysis_summary.ttl
@@ -1,6 +1,6 @@
 # Consolidated schema summary from: .configs/ingest/graph/registry.trig
 # All named graphs aggregated — unique type → property list
-# Generated: 2026-04-29T11:33:15.190Z
+# Generated: 2026-04-29T11:38:35.100Z
 
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .


### PR DESCRIPTION
## Schema Extraction — .configs/ingest/graph/registry.trig

> Automatically extracted by TRSP Schema Extraction on 2026-04-29.

### Summary
- **Named graphs analysed**: 321
- **Node types found**: 704
- **Unique property usages**: 2243
- **Unique types (consolidated)**: 5

### Output files
- `.configs/ingest/graph/schema_analysis.ttl` — per-graph detail (TTL)
- `.configs/ingest/graph/schema_analysis_summary.ttl` — consolidated type→property summary (TTL)