### PR TITLE
Schema extraction: .configs/ingest/graph/registry.trig — 2026-04-29

### DIFF
--- a/.configs/ingest/graph/schema_analysis.ttl
+++ b/.configs/ingest/graph/schema_analysis.ttl
@@ -1,5 +1,5 @@
 # Schema extraction from: .configs/ingest/graph/registry.trig
-# Generated: 2026-04-29T11:38:35.084Z
+# Generated: 2026-04-29T12:00:58.753Z
 
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
@@ -12,31 +12,6 @@
 @prefix schema: <http://schema.org/> .
 @prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
 
-ex:defaultGraph1 a ex:NamedGraph ;
-  rdfs:label "Default Graph"@en .
-
-ex:typeProfile_Catalog a ex:TypeProfile ;
-  ex:inGraph ex:defaultGraph1 ;
-  ex:nodeType dcat:Catalog ;
-  ex:usesProperty dct:contactPoint ;
-  ex:usesProperty dct:publisher ;
-.
-
-ex:typeProfile_CatalogRecord a ex:TypeProfile ;
-  ex:inGraph ex:defaultGraph1 ;
-  ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty prov:wasAssociatedWith ;
-  ex:usesProperty prov:wasGeneratedBy ;
-  ex:usesProperty foaf:primaryTopic ;
-.
-
-ex:typeProfile_Project a ex:TypeProfile ;
-  ex:inGraph ex:defaultGraph1 ;
-  ex:nodeType foaf:Project ;
-  ex:usesProperty dct:contactPoint ;
-  ex:usesProperty dct:publisher ;
-.
-
 eden://harvester/embedded_jsonld/https://anc.plus.ac.at/index.html a ex:NamedGraph ;
   rdfs:label "<eden://harvester/embedded_jsonld/https://anc.plus.ac.at/index.html>"@en .
 
@@ -45,16 +20,51 @@ ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:language ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/embedded_jsonld/https://anc.plus.ac.at/index.html ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://anc.plus.ac.at/index.html ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://anc.plus.ac.at/index.html ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://anc.plus.ac.at/index.html ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://anc.plus.ac.at/index.html ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -62,7 +72,14 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:language ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
@@ -72,20 +89,52 @@ eden://harvester/embedded_jsonld/https://dans.knaw.nl/nl/life-sciences/ a ex:Nam
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/embedded_jsonld/https://dans.knaw.nl/nl/life-sciences/ ;
   ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:language ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/embedded_jsonld/https://dans.knaw.nl/nl/life-sciences/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
 .
 
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://dans.knaw.nl/nl/life-sciences/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:format ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://dans.knaw.nl/nl/life-sciences/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://dans.knaw.nl/nl/life-sciences/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
 ex:typeProfile_Project a ex:TypeProfile ;
   ex:inGraph eden://harvester/embedded_jsonld/https://dans.knaw.nl/nl/life-sciences/ ;
   ex:nodeType foaf:Project ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:language ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
   ex:usesProperty dcat:service ;
 .
 
@@ -95,20 +144,52 @@ eden://harvester/embedded_jsonld/https://dans.knaw.nl/nl/social-sciences-and-hum
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/embedded_jsonld/https://dans.knaw.nl/nl/social-sciences-and-humanities/ ;
   ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:language ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/embedded_jsonld/https://dans.knaw.nl/nl/social-sciences-and-humanities/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
 .
 
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://dans.knaw.nl/nl/social-sciences-and-humanities/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:format ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://dans.knaw.nl/nl/social-sciences-and-humanities/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://dans.knaw.nl/nl/social-sciences-and-humanities/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
 ex:typeProfile_Project a ex:TypeProfile ;
   ex:inGraph eden://harvester/embedded_jsonld/https://dans.knaw.nl/nl/social-sciences-and-humanities/ ;
   ex:nodeType foaf:Project ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:language ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
   ex:usesProperty dcat:service ;
 .
 
@@ -118,46 +199,123 @@ eden://harvester/embedded_jsonld/https://ega-archive.org/ a ex:NamedGraph ;
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/embedded_jsonld/https://ega-archive.org/ ;
   ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/embedded_jsonld/https://ega-archive.org/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
 .
 
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://ega-archive.org/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://ega-archive.org/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://ega-archive.org/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty foaf:name ;
+.
+
 ex:typeProfile_Project a ex:TypeProfile ;
   ex:inGraph eden://harvester/embedded_jsonld/https://ega-archive.org/ ;
   ex:nodeType foaf:Project ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
 .
 
 eden://harvester/embedded_jsonld/https://modelarchive.org/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/embedded_jsonld/https://modelarchive.org/>"@en .
 
+ex:typeProfile_CreativeWork a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://modelarchive.org/ ;
+  ex:nodeType <http://localhost:3030/service_registry_store/CreativeWork> ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_license a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://modelarchive.org/ ;
+  ex:nodeType <http://localhost:3030/service_registry_store/license> ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://modelarchive.org/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/embedded_jsonld/https://modelarchive.org/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/embedded_jsonld/https://modelarchive.org/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://modelarchive.org/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://modelarchive.org/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://modelarchive.org/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
   ex:inGraph eden://harvester/embedded_jsonld/https://modelarchive.org/ ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
 .
 
 eden://harvester/embedded_jsonld/https://naehrwertdaten.ch/de/ a ex:NamedGraph ;
@@ -166,45 +324,125 @@ eden://harvester/embedded_jsonld/https://naehrwertdaten.ch/de/ a ex:NamedGraph ;
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/embedded_jsonld/https://naehrwertdaten.ch/de/ ;
   ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:language ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/embedded_jsonld/https://naehrwertdaten.ch/de/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
 .
 
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://naehrwertdaten.ch/de/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:format ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://naehrwertdaten.ch/de/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://naehrwertdaten.ch/de/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
 ex:typeProfile_Project a ex:TypeProfile ;
   ex:inGraph eden://harvester/embedded_jsonld/https://naehrwertdaten.ch/de/ ;
   ex:nodeType foaf:Project ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:language ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
   ex:usesProperty dcat:service ;
 .
 
 eden://harvester/embedded_jsonld/https://omabrowser.org/oma/home/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/embedded_jsonld/https://omabrowser.org/oma/home/>"@en .
 
+ex:typeProfile_CreativeWork a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://omabrowser.org/oma/home/ ;
+  ex:nodeType <http://localhost:3030/service_registry_store/CreativeWork> ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_license a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://omabrowser.org/oma/home/ ;
+  ex:nodeType <http://localhost:3030/service_registry_store/license> ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://omabrowser.org/oma/home/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/embedded_jsonld/https://omabrowser.org/oma/home/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/embedded_jsonld/https://omabrowser.org/oma/home/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://omabrowser.org/oma/home/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:format ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://omabrowser.org/oma/home/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://omabrowser.org/oma/home/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
   ex:inGraph eden://harvester/embedded_jsonld/https://omabrowser.org/oma/home/ ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
   ex:usesProperty dcat:service ;
 .
 
@@ -214,20 +452,50 @@ eden://harvester/embedded_jsonld/https://pangaea.de/ a ex:NamedGraph ;
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/embedded_jsonld/https://pangaea.de/ ;
   ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:language ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/embedded_jsonld/https://pangaea.de/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
 .
 
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://pangaea.de/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:format ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://pangaea.de/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://pangaea.de/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
 ex:typeProfile_Project a ex:TypeProfile ;
   ex:inGraph eden://harvester/embedded_jsonld/https://pangaea.de/ ;
   ex:nodeType foaf:Project ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:language ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
   ex:usesProperty dcat:service ;
 .
 
@@ -237,58 +505,171 @@ eden://harvester/embedded_jsonld/https://reactome.org/ a ex:NamedGraph ;
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/embedded_jsonld/https://reactome.org/ ;
   ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/embedded_jsonld/https://reactome.org/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
 .
 
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://reactome.org/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:format ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://reactome.org/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://reactome.org/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
 ex:typeProfile_Project a ex:TypeProfile ;
   ex:inGraph eden://harvester/embedded_jsonld/https://reactome.org/ ;
   ex:nodeType foaf:Project ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
   ex:usesProperty dcat:service ;
 .
 
 eden://harvester/embedded_jsonld/https://recherche.data.gouv.fr/en/page/about-recherche-data-gouv a ex:NamedGraph ;
   rdfs:label "<eden://harvester/embedded_jsonld/https://recherche.data.gouv.fr/en/page/about-recherche-data-gouv>"@en .
 
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://recherche.data.gouv.fr/en/page/about-recherche-data-gouv ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/embedded_jsonld/https://recherche.data.gouv.fr/en/page/about-recherche-data-gouv ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
 .
 
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://recherche.data.gouv.fr/en/page/about-recherche-data-gouv ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://recherche.data.gouv.fr/en/page/about-recherche-data-gouv ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://recherche.data.gouv.fr/en/page/about-recherche-data-gouv ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+.
+
 eden://harvester/embedded_jsonld/https://string-db.org/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/embedded_jsonld/https://string-db.org/>"@en .
+
+ex:typeProfile_CreativeWork a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://string-db.org/ ;
+  ex:nodeType <http://localhost:3030/service_registry_store/CreativeWork> ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_license a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://string-db.org/ ;
+  ex:nodeType <http://localhost:3030/service_registry_store/license> ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://string-db.org/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
 
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/embedded_jsonld/https://string-db.org/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/embedded_jsonld/https://string-db.org/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://string-db.org/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:format ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://string-db.org/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://string-db.org/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://string-db.org/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
   ex:inGraph eden://harvester/embedded_jsonld/https://string-db.org/ ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
   ex:usesProperty dcat:service ;
 .
 
@@ -298,44 +679,124 @@ eden://harvester/embedded_jsonld/https://ukdataservice.ac.uk/about/ a ex:NamedGr
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/embedded_jsonld/https://ukdataservice.ac.uk/about/ ;
   ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:language ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/embedded_jsonld/https://ukdataservice.ac.uk/about/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
 .
 
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://ukdataservice.ac.uk/about/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:format ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://ukdataservice.ac.uk/about/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://ukdataservice.ac.uk/about/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
 ex:typeProfile_Project a ex:TypeProfile ;
   ex:inGraph eden://harvester/embedded_jsonld/https://ukdataservice.ac.uk/about/ ;
   ex:nodeType foaf:Project ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:language ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
   ex:usesProperty dcat:service ;
 .
 
 eden://harvester/embedded_jsonld/https://www.bgee.org/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/embedded_jsonld/https://www.bgee.org/>"@en .
 
+ex:typeProfile_citation a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://www.bgee.org/ ;
+  ex:nodeType <http://localhost:3030/service_registry_store/citation> ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_CreativeWork a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://www.bgee.org/ ;
+  ex:nodeType <http://localhost:3030/service_registry_store/CreativeWork> ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_license a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://www.bgee.org/ ;
+  ex:nodeType <http://localhost:3030/service_registry_store/license> ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://www.bgee.org/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/embedded_jsonld/https://www.bgee.org/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/embedded_jsonld/https://www.bgee.org/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://www.bgee.org/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://www.bgee.org/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
   ex:inGraph eden://harvester/embedded_jsonld/https://www.bgee.org/ ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
 .
 
 eden://harvester/embedded_jsonld/https://www.cathdb.info/ a ex:NamedGraph ;
@@ -344,43 +805,135 @@ eden://harvester/embedded_jsonld/https://www.cathdb.info/ a ex:NamedGraph ;
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/embedded_jsonld/https://www.cathdb.info/ ;
   ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/embedded_jsonld/https://www.cathdb.info/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://www.cathdb.info/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://www.cathdb.info/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://www.cathdb.info/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
   ex:inGraph eden://harvester/embedded_jsonld/https://www.cathdb.info/ ;
   ex:nodeType foaf:Project ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
 .
 
 eden://harvester/embedded_jsonld/https://www.cellosaurus.org/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/embedded_jsonld/https://www.cellosaurus.org/>"@en .
 
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://www.cellosaurus.org/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/embedded_jsonld/https://www.cellosaurus.org/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
 .
 
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://www.cellosaurus.org/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://www.cellosaurus.org/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://www.cellosaurus.org/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+.
+
 eden://harvester/embedded_jsonld/https://www.crossda.hr/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/embedded_jsonld/https://www.crossda.hr/>"@en .
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://www.crossda.hr/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+.
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/embedded_jsonld/https://www.crossda.hr/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://www.crossda.hr/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://www.crossda.hr/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://www.crossda.hr/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
 .
 
 eden://harvester/embedded_jsonld/https://www.ebi.ac.uk/biosamples/ a ex:NamedGraph ;
@@ -389,21 +942,49 @@ eden://harvester/embedded_jsonld/https://www.ebi.ac.uk/biosamples/ a ex:NamedGra
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/embedded_jsonld/https://www.ebi.ac.uk/biosamples/ ;
   ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/embedded_jsonld/https://www.ebi.ac.uk/biosamples/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
 .
 
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://www.ebi.ac.uk/biosamples/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://www.ebi.ac.uk/biosamples/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://www.ebi.ac.uk/biosamples/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty foaf:name ;
+.
+
 ex:typeProfile_Project a ex:TypeProfile ;
   ex:inGraph eden://harvester/embedded_jsonld/https://www.ebi.ac.uk/biosamples/ ;
   ex:nodeType foaf:Project ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
 .
 
 eden://harvester/embedded_jsonld/https://www.fairdata.fi/ a ex:NamedGraph ;
@@ -412,60 +993,188 @@ eden://harvester/embedded_jsonld/https://www.fairdata.fi/ a ex:NamedGraph ;
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/embedded_jsonld/https://www.fairdata.fi/ ;
   ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:language ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/embedded_jsonld/https://www.fairdata.fi/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
 .
 
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://www.fairdata.fi/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:format ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://www.fairdata.fi/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://www.fairdata.fi/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://www.fairdata.fi/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
+.
+
 ex:typeProfile_Project a ex:TypeProfile ;
   ex:inGraph eden://harvester/embedded_jsonld/https://www.fairdata.fi/ ;
   ex:nodeType foaf:Project ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:language ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
   ex:usesProperty dcat:service ;
 .
 
 eden://harvester/embedded_jsonld/https://www.kielipankki.fi/language-bank/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/embedded_jsonld/https://www.kielipankki.fi/language-bank/>"@en .
 
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://www.kielipankki.fi/language-bank/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/embedded_jsonld/https://www.kielipankki.fi/language-bank/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
 .
 
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://www.kielipankki.fi/language-bank/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://www.kielipankki.fi/language-bank/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://www.kielipankki.fi/language-bank/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+.
+
 eden://harvester/embedded_jsonld/https://www.orthodb.org/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/embedded_jsonld/https://www.orthodb.org/>"@en .
+
+ex:typeProfile_CreativeWork a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://www.orthodb.org/ ;
+  ex:nodeType <http://localhost:3030/service_registry_store/CreativeWork> ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_license a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://www.orthodb.org/ ;
+  ex:nodeType <http://localhost:3030/service_registry_store/license> ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://www.orthodb.org/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
 
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/embedded_jsonld/https://www.orthodb.org/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/embedded_jsonld/https://www.orthodb.org/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://www.orthodb.org/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:format ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://www.orthodb.org/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://www.orthodb.org/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://www.orthodb.org/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
   ex:inGraph eden://harvester/embedded_jsonld/https://www.orthodb.org/ ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
   ex:usesProperty dcat:service ;
 .
 
@@ -475,20 +1184,50 @@ eden://harvester/embedded_jsonld/https://www.wdc-climate.de/ui/ a ex:NamedGraph 
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/embedded_jsonld/https://www.wdc-climate.de/ui/ ;
   ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:language ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/embedded_jsonld/https://www.wdc-climate.de/ui/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
 .
 
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://www.wdc-climate.de/ui/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:format ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://www.wdc-climate.de/ui/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/embedded_jsonld/https://www.wdc-climate.de/ui/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
 ex:typeProfile_Project a ex:TypeProfile ;
   ex:inGraph eden://harvester/embedded_jsonld/https://www.wdc-climate.de/ui/ ;
   ex:nodeType foaf:Project ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:language ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
   ex:usesProperty dcat:service ;
 .
 
@@ -498,40 +1237,109 @@ eden://harvester/fairicat_services/https://rdr.kuleuven.be/ a ex:NamedGraph ;
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairicat_services/https://rdr.kuleuven.be/ ;
   ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairicat_services/https://rdr.kuleuven.be/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
 .
 
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairicat_services/https://rdr.kuleuven.be/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:format ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairicat_services/https://rdr.kuleuven.be/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairicat_services/https://rdr.kuleuven.be/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
 ex:typeProfile_Project a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairicat_services/https://rdr.kuleuven.be/ ;
   ex:nodeType foaf:Project ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dcat:service ;
 .
 
 eden://harvester/fairsharing/https://about.coscine.de/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/fairsharing/https://about.coscine.de/>"@en .
 
+ex:typeProfile_ex_SustainabilityPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://about.coscine.de/ ;
+  ex:nodeType <ex:SustainabilityPolicy> ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://about.coscine.de/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://about.coscine.de/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://about.coscine.de/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://about.coscine.de/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://about.coscine.de/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://about.coscine.de/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://about.coscine.de/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -539,26 +1347,81 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+.
+
+ex:typeProfile_premis_PreservationPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://about.coscine.de/ ;
+  ex:nodeType <premis:PreservationPolicy> ;
+  ex:usesProperty dct:title ;
 .
 
 eden://harvester/fairsharing/https://agroportal.eu/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/fairsharing/https://agroportal.eu/>"@en .
 
+ex:typeProfile_ex_SustainabilityPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://agroportal.eu/ ;
+  ex:nodeType <ex:SustainabilityPolicy> ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://agroportal.eu/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://agroportal.eu/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://agroportal.eu/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://agroportal.eu/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://agroportal.eu/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://agroportal.eu/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://agroportal.eu/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -566,51 +1429,140 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 eden://harvester/fairsharing/https://anc.plus.ac.at/index.html a ex:NamedGraph ;
   rdfs:label "<eden://harvester/fairsharing/https://anc.plus.ac.at/index.html>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://anc.plus.ac.at/index.html ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://anc.plus.ac.at/index.html ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://anc.plus.ac.at/index.html ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
-  ex:usesProperty dcat:service ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://anc.plus.ac.at/index.html ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://anc.plus.ac.at/index.html ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://anc.plus.ac.at/index.html ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://anc.plus.ac.at/index.html ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://anc.plus.ac.at/index.html ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
-  ex:usesProperty dcat:service ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+.
+
+ex:typeProfile_premis_PreservationPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://anc.plus.ac.at/index.html ;
+  ex:nodeType <premis:PreservationPolicy> ;
+  ex:usesProperty dct:title ;
 .
 
 eden://harvester/fairsharing/https://archiv.soc.cas.cz/en/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/fairsharing/https://archiv.soc.cas.cz/en/>"@en .
 
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://archiv.soc.cas.cz/en/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://archiv.soc.cas.cz/en/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://archiv.soc.cas.cz/en/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://archiv.soc.cas.cz/en/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://archiv.soc.cas.cz/en/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://archiv.soc.cas.cz/en/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -618,26 +1570,76 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 eden://harvester/fairsharing/https://aussda.at/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/fairsharing/https://aussda.at/>"@en .
 
+ex:typeProfile_ex_SustainabilityPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://aussda.at/ ;
+  ex:nodeType <ex:SustainabilityPolicy> ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://aussda.at/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://aussda.at/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://aussda.at/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://aussda.at/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://aussda.at/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://aussda.at/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://aussda.at/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -645,51 +1647,137 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+.
+
+ex:typeProfile_premis_PreservationPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://aussda.at/ ;
+  ex:nodeType <premis:PreservationPolicy> ;
+  ex:usesProperty dct:title ;
 .
 
 eden://harvester/fairsharing/https://bacdive.dsmz.de/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/fairsharing/https://bacdive.dsmz.de/>"@en .
 
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://bacdive.dsmz.de/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://bacdive.dsmz.de/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://bacdive.dsmz.de/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://bacdive.dsmz.de/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://bacdive.dsmz.de/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://bacdive.dsmz.de/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://bacdive.dsmz.de/ ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 eden://harvester/fairsharing/https://borealisdata.ca/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/fairsharing/https://borealisdata.ca/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://borealisdata.ca/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://borealisdata.ca/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://borealisdata.ca/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://borealisdata.ca/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://borealisdata.ca/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://borealisdata.ca/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://borealisdata.ca/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -697,76 +1785,207 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+.
+
+ex:typeProfile_premis_PreservationPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://borealisdata.ca/ ;
+  ex:nodeType <premis:PreservationPolicy> ;
+  ex:usesProperty dct:title ;
 .
 
 eden://harvester/fairsharing/https://cds.climate.copernicus.eu/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/fairsharing/https://cds.climate.copernicus.eu/>"@en .
 
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://cds.climate.copernicus.eu/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://cds.climate.copernicus.eu/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://cds.climate.copernicus.eu/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://cds.climate.copernicus.eu/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://cds.climate.copernicus.eu/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://cds.climate.copernicus.eu/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://cds.climate.copernicus.eu/ ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 eden://harvester/fairsharing/https://cer.ihtm.bg.ac.rs/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/fairsharing/https://cer.ihtm.bg.ac.rs/>"@en .
 
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://cer.ihtm.bg.ac.rs/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://cer.ihtm.bg.ac.rs/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://cer.ihtm.bg.ac.rs/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://cer.ihtm.bg.ac.rs/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://cer.ihtm.bg.ac.rs/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://cer.ihtm.bg.ac.rs/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://cer.ihtm.bg.ac.rs/ ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 eden://harvester/fairsharing/https://dass.credi.ba/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/fairsharing/https://dass.credi.ba/>"@en .
 
+ex:typeProfile_ex_SustainabilityPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://dass.credi.ba/ ;
+  ex:nodeType <ex:SustainabilityPolicy> ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://dass.credi.ba/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://dass.credi.ba/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://dass.credi.ba/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://dass.credi.ba/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://dass.credi.ba/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://dass.credi.ba/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://dass.credi.ba/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -774,26 +1993,80 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+.
+
+ex:typeProfile_premis_PreservationPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://dass.credi.ba/ ;
+  ex:nodeType <premis:PreservationPolicy> ;
+  ex:usesProperty dct:title ;
 .
 
 eden://harvester/fairsharing/https://data.4tu.nl/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/fairsharing/https://data.4tu.nl/>"@en .
 
+ex:typeProfile_ex_SustainabilityPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://data.4tu.nl/ ;
+  ex:nodeType <ex:SustainabilityPolicy> ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://data.4tu.nl/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://data.4tu.nl/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://data.4tu.nl/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://data.4tu.nl/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://data.4tu.nl/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://data.4tu.nl/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://data.4tu.nl/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -801,76 +2074,193 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+.
+
+ex:typeProfile_premis_PreservationPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://data.4tu.nl/ ;
+  ex:nodeType <premis:PreservationPolicy> ;
+  ex:usesProperty dct:title ;
 .
 
 eden://harvester/fairsharing/https://data.progedo.fr/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/fairsharing/https://data.progedo.fr/>"@en .
 
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://data.progedo.fr/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://data.progedo.fr/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://data.progedo.fr/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://data.progedo.fr/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://data.progedo.fr/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://data.progedo.fr/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://data.progedo.fr/ ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 eden://harvester/fairsharing/https://data.sciencespo.fr/dataverse/cdsp a ex:NamedGraph ;
   rdfs:label "<eden://harvester/fairsharing/https://data.sciencespo.fr/dataverse/cdsp>"@en .
 
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://data.sciencespo.fr/dataverse/cdsp ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://data.sciencespo.fr/dataverse/cdsp ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://data.sciencespo.fr/dataverse/cdsp ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://data.sciencespo.fr/dataverse/cdsp ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://data.sciencespo.fr/dataverse/cdsp ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://data.sciencespo.fr/dataverse/cdsp ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://data.sciencespo.fr/dataverse/cdsp ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 eden://harvester/fairsharing/https://datarepositorium.uminho.pt/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/fairsharing/https://datarepositorium.uminho.pt/>"@en .
 
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://datarepositorium.uminho.pt/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://datarepositorium.uminho.pt/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://datarepositorium.uminho.pt/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://datarepositorium.uminho.pt/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://datarepositorium.uminho.pt/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://datarepositorium.uminho.pt/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -878,26 +2268,130 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+.
+
+eden://harvester/fairsharing/https://dataservices.gfz-potsdam.de/web/ a ex:NamedGraph ;
+  rdfs:label "<eden://harvester/fairsharing/https://dataservices.gfz-potsdam.de/web/>"@en .
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://dataservices.gfz-potsdam.de/web/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://dataservices.gfz-potsdam.de/web/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+.
+
+ex:typeProfile_CatalogRecord a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://dataservices.gfz-potsdam.de/web/ ;
+  ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
+  ex:usesProperty prov:wasAssociatedWith ;
+  ex:usesProperty prov:wasGeneratedBy ;
+  ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://dataservices.gfz-potsdam.de/web/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://dataservices.gfz-potsdam.de/web/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://dataservices.gfz-potsdam.de/web/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty foaf:name ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://dataservices.gfz-potsdam.de/web/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 eden://harvester/fairsharing/https://dataverse.no/dataverse/trolling a ex:NamedGraph ;
   rdfs:label "<eden://harvester/fairsharing/https://dataverse.no/dataverse/trolling>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://dataverse.no/dataverse/trolling ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://dataverse.no/dataverse/trolling ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://dataverse.no/dataverse/trolling ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://dataverse.no/dataverse/trolling ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://dataverse.no/dataverse/trolling ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://dataverse.no/dataverse/trolling ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://dataverse.no/dataverse/trolling ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -905,26 +2399,69 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+.
+
+ex:typeProfile_premis_PreservationPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://dataverse.no/dataverse/trolling ;
+  ex:nodeType <premis:PreservationPolicy> ;
+  ex:usesProperty dct:title ;
 .
 
 eden://harvester/fairsharing/https://datice.is/is a ex:NamedGraph ;
   rdfs:label "<eden://harvester/fairsharing/https://datice.is/is>"@en .
 
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://datice.is/is ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://datice.is/is ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://datice.is/is ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://datice.is/is ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://datice.is/is ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://datice.is/is ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -932,26 +2469,63 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 eden://harvester/fairsharing/https://ega-archive.org/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/fairsharing/https://ega-archive.org/>"@en .
 
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://ega-archive.org/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://ega-archive.org/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://ega-archive.org/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://ega-archive.org/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://ega-archive.org/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://ega-archive.org/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -959,50 +2533,124 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 eden://harvester/fairsharing/https://glittr.org/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/fairsharing/https://glittr.org/>"@en .
 
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://glittr.org/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://glittr.org/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://glittr.org/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://glittr.org/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://glittr.org/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://glittr.org/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://glittr.org/ ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 eden://harvester/fairsharing/https://lida.dataverse.lt/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/fairsharing/https://lida.dataverse.lt/>"@en .
 
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://lida.dataverse.lt/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://lida.dataverse.lt/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://lida.dataverse.lt/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://lida.dataverse.lt/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://lida.dataverse.lt/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://lida.dataverse.lt/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -1010,25 +2658,63 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 eden://harvester/fairsharing/https://modelarchive.org/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/fairsharing/https://modelarchive.org/>"@en .
 
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://modelarchive.org/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://modelarchive.org/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://modelarchive.org/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://modelarchive.org/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://modelarchive.org/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://modelarchive.org/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -1036,26 +2722,63 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 eden://harvester/fairsharing/https://omabrowser.org/oma/home/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/fairsharing/https://omabrowser.org/oma/home/>"@en .
 
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://omabrowser.org/oma/home/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://omabrowser.org/oma/home/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://omabrowser.org/oma/home/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://omabrowser.org/oma/home/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://omabrowser.org/oma/home/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://omabrowser.org/oma/home/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -1063,26 +2786,76 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 eden://harvester/fairsharing/https://pangaea.de/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/fairsharing/https://pangaea.de/>"@en .
 
+ex:typeProfile_ex_SustainabilityPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://pangaea.de/ ;
+  ex:nodeType <ex:SustainabilityPolicy> ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://pangaea.de/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://pangaea.de/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://pangaea.de/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://pangaea.de/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://pangaea.de/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://pangaea.de/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://pangaea.de/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -1090,26 +2863,75 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+.
+
+ex:typeProfile_premis_PreservationPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://pangaea.de/ ;
+  ex:nodeType <premis:PreservationPolicy> ;
+  ex:usesProperty dct:title ;
 .
 
 eden://harvester/fairsharing/https://qdr.syr.edu/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/fairsharing/https://qdr.syr.edu/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://qdr.syr.edu/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://qdr.syr.edu/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://qdr.syr.edu/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://qdr.syr.edu/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://qdr.syr.edu/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://qdr.syr.edu/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://qdr.syr.edu/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -1117,26 +2939,74 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+.
+
+ex:typeProfile_premis_PreservationPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://qdr.syr.edu/ ;
+  ex:nodeType <premis:PreservationPolicy> ;
+  ex:usesProperty dct:title ;
 .
 
 eden://harvester/fairsharing/https://rdr.kuleuven.be/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/fairsharing/https://rdr.kuleuven.be/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://rdr.kuleuven.be/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://rdr.kuleuven.be/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://rdr.kuleuven.be/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://rdr.kuleuven.be/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://rdr.kuleuven.be/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://rdr.kuleuven.be/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://rdr.kuleuven.be/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -1144,26 +3014,74 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+.
+
+ex:typeProfile_premis_PreservationPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://rdr.kuleuven.be/ ;
+  ex:nodeType <premis:PreservationPolicy> ;
+  ex:usesProperty dct:title ;
 .
 
 eden://harvester/fairsharing/https://reactome.org/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/fairsharing/https://reactome.org/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://reactome.org/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://reactome.org/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://reactome.org/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://reactome.org/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://reactome.org/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://reactome.org/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://reactome.org/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -1171,7 +3089,18 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+.
+
+ex:typeProfile_premis_PreservationPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://reactome.org/ ;
+  ex:nodeType <premis:PreservationPolicy> ;
+  ex:usesProperty dct:title ;
 .
 
 eden://harvester/fairsharing/https://recherche.data.gouv.fr/en/page/about-recherche-data-gouv a ex:NamedGraph ;
@@ -1181,47 +3110,115 @@ ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://recherche.data.gouv.fr/en/page/about-recherche-data-gouv ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://recherche.data.gouv.fr/en/page/about-recherche-data-gouv ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://recherche.data.gouv.fr/en/page/about-recherche-data-gouv ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://recherche.data.gouv.fr/en/page/about-recherche-data-gouv ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://recherche.data.gouv.fr/en/page/about-recherche-data-gouv ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://recherche.data.gouv.fr/en/page/about-recherche-data-gouv ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 eden://harvester/fairsharing/https://repo.researchdata.hu/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/fairsharing/https://repo.researchdata.hu/>"@en .
 
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://repo.researchdata.hu/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://repo.researchdata.hu/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://repo.researchdata.hu/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://repo.researchdata.hu/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://repo.researchdata.hu/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://repo.researchdata.hu/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://repo.researchdata.hu/ ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 eden://harvester/fairsharing/https://sikt.no/en/archiving-research-data a ex:NamedGraph ;
@@ -1232,6 +3229,12 @@ ex:typeProfile_ex_DepositionPolicy a ex:TypeProfile ;
   ex:nodeType <ex:DepositionPolicy> ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 ex:typeProfile_Policy a ex:TypeProfile ;
@@ -1239,6 +3242,18 @@ ex:typeProfile_Policy a ex:TypeProfile ;
   ex:nodeType dct:Policy ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://sikt.no/en/archiving-research-data ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
 .
 
 ex:typeProfile_Catalog a ex:TypeProfile ;
@@ -1246,14 +3261,34 @@ ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://sikt.no/en/archiving-research-data ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://sikt.no/en/archiving-research-data ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://sikt.no/en/archiving-research-data ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -1261,25 +3296,62 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 eden://harvester/fairsharing/https://string-db.org/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/fairsharing/https://string-db.org/>"@en .
 
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://string-db.org/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://string-db.org/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://string-db.org/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://string-db.org/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://string-db.org/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://string-db.org/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -1287,26 +3359,69 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 eden://harvester/fairsharing/https://ukdataservice.ac.uk/about/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/fairsharing/https://ukdataservice.ac.uk/about/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://ukdataservice.ac.uk/about/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://ukdataservice.ac.uk/about/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://ukdataservice.ac.uk/about/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://ukdataservice.ac.uk/about/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://ukdataservice.ac.uk/about/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://ukdataservice.ac.uk/about/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://ukdataservice.ac.uk/about/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -1314,26 +3429,76 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+.
+
+ex:typeProfile_premis_PreservationPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://ukdataservice.ac.uk/about/ ;
+  ex:nodeType <premis:PreservationPolicy> ;
+  ex:usesProperty dct:title ;
 .
 
 eden://harvester/fairsharing/https://www.adp.fdv.uni-lj.si/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/fairsharing/https://www.adp.fdv.uni-lj.si/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.adp.fdv.uni-lj.si/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.adp.fdv.uni-lj.si/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://www.adp.fdv.uni-lj.si/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://www.adp.fdv.uni-lj.si/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.adp.fdv.uni-lj.si/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.adp.fdv.uni-lj.si/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.adp.fdv.uni-lj.si/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -1341,107 +3506,263 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+.
+
+ex:typeProfile_premis_PreservationPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.adp.fdv.uni-lj.si/ ;
+  ex:nodeType <premis:PreservationPolicy> ;
+  ex:usesProperty dct:title ;
 .
 
 eden://harvester/fairsharing/https://www.bgee.org/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/fairsharing/https://www.bgee.org/>"@en .
 
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.bgee.org/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://www.bgee.org/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://www.bgee.org/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.bgee.org/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.bgee.org/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.bgee.org/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://www.bgee.org/ ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 eden://harvester/fairsharing/https://www.cathdb.info/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/fairsharing/https://www.cathdb.info/>"@en .
 
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.cathdb.info/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://www.cathdb.info/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://www.cathdb.info/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.cathdb.info/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.cathdb.info/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.cathdb.info/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://www.cathdb.info/ ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 eden://harvester/fairsharing/https://www.cellosaurus.org/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/fairsharing/https://www.cellosaurus.org/>"@en .
 
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.cellosaurus.org/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://www.cellosaurus.org/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://www.cellosaurus.org/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.cellosaurus.org/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.cellosaurus.org/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.cellosaurus.org/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://www.cellosaurus.org/ ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 eden://harvester/fairsharing/https://www.clarin.eu/content/national-consortia a ex:NamedGraph ;
   rdfs:label "<eden://harvester/fairsharing/https://www.clarin.eu/content/national-consortia>"@en .
 
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.clarin.eu/content/national-consortia ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://www.clarin.eu/content/national-consortia ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://www.clarin.eu/content/national-consortia ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.clarin.eu/content/national-consortia ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.clarin.eu/content/national-consortia ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.clarin.eu/content/national-consortia ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://www.clarin.eu/content/national-consortia ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 eden://harvester/fairsharing/https://www.crossda.hr/ a ex:NamedGraph ;
@@ -1450,40 +3771,116 @@ eden://harvester/fairsharing/https://www.crossda.hr/ a ex:NamedGraph ;
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://www.crossda.hr/ ;
   ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://www.crossda.hr/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
 .
 
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.crossda.hr/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.crossda.hr/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.crossda.hr/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty foaf:name ;
+.
+
 ex:typeProfile_Project a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://www.crossda.hr/ ;
   ex:nodeType foaf:Project ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 eden://harvester/fairsharing/https://www.ebi.ac.uk/bioimage-archive/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/fairsharing/https://www.ebi.ac.uk/bioimage-archive/>"@en .
 
+ex:typeProfile_ex_SustainabilityPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/bioimage-archive/ ;
+  ex:nodeType <ex:SustainabilityPolicy> ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/bioimage-archive/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/bioimage-archive/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/bioimage-archive/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/bioimage-archive/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/bioimage-archive/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/bioimage-archive/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/bioimage-archive/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -1491,26 +3888,82 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+.
+
+ex:typeProfile_premis_PreservationPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/bioimage-archive/ ;
+  ex:nodeType <premis:PreservationPolicy> ;
+  ex:usesProperty dct:title ;
 .
 
 eden://harvester/fairsharing/https://www.ebi.ac.uk/biosamples/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/fairsharing/https://www.ebi.ac.uk/biosamples/>"@en .
 
+ex:typeProfile_ex_SustainabilityPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/biosamples/ ;
+  ex:nodeType <ex:SustainabilityPolicy> ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/biosamples/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/biosamples/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/biosamples/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/biosamples/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/biosamples/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/biosamples/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/biosamples/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -1518,26 +3971,82 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+.
+
+ex:typeProfile_premis_PreservationPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/biosamples/ ;
+  ex:nodeType <premis:PreservationPolicy> ;
+  ex:usesProperty dct:title ;
 .
 
 eden://harvester/fairsharing/https://www.ebi.ac.uk/biostudies/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/fairsharing/https://www.ebi.ac.uk/biostudies/>"@en .
 
+ex:typeProfile_ex_SustainabilityPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/biostudies/ ;
+  ex:nodeType <ex:SustainabilityPolicy> ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/biostudies/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/biostudies/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/biostudies/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/biostudies/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/biostudies/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/biostudies/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/biostudies/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -1545,26 +4054,82 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+.
+
+ex:typeProfile_premis_PreservationPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/biostudies/ ;
+  ex:nodeType <premis:PreservationPolicy> ;
+  ex:usesProperty dct:title ;
 .
 
 eden://harvester/fairsharing/https://www.ebi.ac.uk/biostudies/arrayexpress a ex:NamedGraph ;
   rdfs:label "<eden://harvester/fairsharing/https://www.ebi.ac.uk/biostudies/arrayexpress>"@en .
 
+ex:typeProfile_ex_SustainabilityPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/biostudies/arrayexpress ;
+  ex:nodeType <ex:SustainabilityPolicy> ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/biostudies/arrayexpress ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/biostudies/arrayexpress ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/biostudies/arrayexpress ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/biostudies/arrayexpress ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/biostudies/arrayexpress ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/biostudies/arrayexpress ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/biostudies/arrayexpress ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -1572,26 +4137,82 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+.
+
+ex:typeProfile_premis_PreservationPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/biostudies/arrayexpress ;
+  ex:nodeType <premis:PreservationPolicy> ;
+  ex:usesProperty dct:title ;
 .
 
 eden://harvester/fairsharing/https://www.ebi.ac.uk/chembl/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/fairsharing/https://www.ebi.ac.uk/chembl/>"@en .
 
+ex:typeProfile_ex_SustainabilityPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/chembl/ ;
+  ex:nodeType <ex:SustainabilityPolicy> ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/chembl/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/chembl/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/chembl/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/chembl/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/chembl/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/chembl/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/chembl/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -1599,26 +4220,82 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+.
+
+ex:typeProfile_premis_PreservationPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/chembl/ ;
+  ex:nodeType <premis:PreservationPolicy> ;
+  ex:usesProperty dct:title ;
 .
 
 eden://harvester/fairsharing/https://www.ebi.ac.uk/emdb/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/fairsharing/https://www.ebi.ac.uk/emdb/>"@en .
 
+ex:typeProfile_ex_SustainabilityPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/emdb/ ;
+  ex:nodeType <ex:SustainabilityPolicy> ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/emdb/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/emdb/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/emdb/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/emdb/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/emdb/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/emdb/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/emdb/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -1626,26 +4303,82 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+.
+
+ex:typeProfile_premis_PreservationPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/emdb/ ;
+  ex:nodeType <premis:PreservationPolicy> ;
+  ex:usesProperty dct:title ;
 .
 
 eden://harvester/fairsharing/https://www.ebi.ac.uk/empiar/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/fairsharing/https://www.ebi.ac.uk/empiar/>"@en .
 
+ex:typeProfile_ex_SustainabilityPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/empiar/ ;
+  ex:nodeType <ex:SustainabilityPolicy> ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/empiar/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/empiar/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/empiar/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/empiar/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/empiar/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/empiar/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/empiar/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -1653,26 +4386,82 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+.
+
+ex:typeProfile_premis_PreservationPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/empiar/ ;
+  ex:nodeType <premis:PreservationPolicy> ;
+  ex:usesProperty dct:title ;
 .
 
 eden://harvester/fairsharing/https://www.ebi.ac.uk/ena/browser/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/fairsharing/https://www.ebi.ac.uk/ena/browser/>"@en .
 
+ex:typeProfile_ex_SustainabilityPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/ena/browser/ ;
+  ex:nodeType <ex:SustainabilityPolicy> ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/ena/browser/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/ena/browser/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/ena/browser/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/ena/browser/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/ena/browser/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/ena/browser/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/ena/browser/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -1680,26 +4469,82 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+.
+
+ex:typeProfile_premis_PreservationPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/ena/browser/ ;
+  ex:nodeType <premis:PreservationPolicy> ;
+  ex:usesProperty dct:title ;
 .
 
 eden://harvester/fairsharing/https://www.ebi.ac.uk/eva/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/fairsharing/https://www.ebi.ac.uk/eva/>"@en .
 
+ex:typeProfile_ex_SustainabilityPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/eva/ ;
+  ex:nodeType <ex:SustainabilityPolicy> ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/eva/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/eva/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/eva/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/eva/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/eva/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/eva/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/eva/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -1707,26 +4552,82 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+.
+
+ex:typeProfile_premis_PreservationPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/eva/ ;
+  ex:nodeType <premis:PreservationPolicy> ;
+  ex:usesProperty dct:title ;
 .
 
 eden://harvester/fairsharing/https://www.ebi.ac.uk/gwas/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/fairsharing/https://www.ebi.ac.uk/gwas/>"@en .
 
+ex:typeProfile_ex_SustainabilityPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/gwas/ ;
+  ex:nodeType <ex:SustainabilityPolicy> ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/gwas/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/gwas/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/gwas/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/gwas/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/gwas/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/gwas/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/gwas/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -1734,26 +4635,82 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+.
+
+ex:typeProfile_premis_PreservationPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/gwas/ ;
+  ex:nodeType <premis:PreservationPolicy> ;
+  ex:usesProperty dct:title ;
 .
 
 eden://harvester/fairsharing/https://www.ebi.ac.uk/intact/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/fairsharing/https://www.ebi.ac.uk/intact/>"@en .
 
+ex:typeProfile_ex_SustainabilityPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/intact/ ;
+  ex:nodeType <ex:SustainabilityPolicy> ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/intact/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/intact/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/intact/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/intact/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/intact/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/intact/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/intact/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -1761,26 +4718,82 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+.
+
+ex:typeProfile_premis_PreservationPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/intact/ ;
+  ex:nodeType <premis:PreservationPolicy> ;
+  ex:usesProperty dct:title ;
 .
 
 eden://harvester/fairsharing/https://www.ebi.ac.uk/metabolights/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/fairsharing/https://www.ebi.ac.uk/metabolights/>"@en .
 
+ex:typeProfile_ex_SustainabilityPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/metabolights/ ;
+  ex:nodeType <ex:SustainabilityPolicy> ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/metabolights/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/metabolights/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/metabolights/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/metabolights/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/metabolights/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/metabolights/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/metabolights/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -1788,26 +4801,82 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+.
+
+ex:typeProfile_premis_PreservationPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/metabolights/ ;
+  ex:nodeType <premis:PreservationPolicy> ;
+  ex:usesProperty dct:title ;
 .
 
 eden://harvester/fairsharing/https://www.ebi.ac.uk/pdbe/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/fairsharing/https://www.ebi.ac.uk/pdbe/>"@en .
 
+ex:typeProfile_ex_SustainabilityPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/pdbe/ ;
+  ex:nodeType <ex:SustainabilityPolicy> ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/pdbe/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/pdbe/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/pdbe/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/pdbe/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/pdbe/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/pdbe/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/pdbe/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -1815,26 +4884,82 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+.
+
+ex:typeProfile_premis_PreservationPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/pdbe/ ;
+  ex:nodeType <premis:PreservationPolicy> ;
+  ex:usesProperty dct:title ;
 .
 
 eden://harvester/fairsharing/https://www.ebi.ac.uk/pride/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/fairsharing/https://www.ebi.ac.uk/pride/>"@en .
 
+ex:typeProfile_ex_SustainabilityPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/pride/ ;
+  ex:nodeType <ex:SustainabilityPolicy> ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/pride/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/pride/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/pride/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/pride/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/pride/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/pride/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/pride/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -1842,99 +4967,288 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+.
+
+ex:typeProfile_premis_PreservationPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ebi.ac.uk/pride/ ;
+  ex:nodeType <premis:PreservationPolicy> ;
+  ex:usesProperty dct:title ;
 .
 
 eden://harvester/fairsharing/https://www.fairdata.fi/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/fairsharing/https://www.fairdata.fi/>"@en .
 
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.fairdata.fi/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://www.fairdata.fi/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://www.fairdata.fi/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.fairdata.fi/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.fairdata.fi/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.fairdata.fi/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://www.fairdata.fi/ ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 eden://harvester/fairsharing/https://www.fsd.tuni.fi/en/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/fairsharing/https://www.fsd.tuni.fi/en/>"@en .
 
+ex:typeProfile_ex_SustainabilityPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.fsd.tuni.fi/en/ ;
+  ex:nodeType <ex:SustainabilityPolicy> ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.fsd.tuni.fi/en/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.fsd.tuni.fi/en/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://www.fsd.tuni.fi/en/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://www.fsd.tuni.fi/en/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.fsd.tuni.fi/en/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.fsd.tuni.fi/en/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.fsd.tuni.fi/en/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://www.fsd.tuni.fi/en/ ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+.
+
+ex:typeProfile_premis_PreservationPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.fsd.tuni.fi/en/ ;
+  ex:nodeType <premis:PreservationPolicy> ;
+  ex:usesProperty dct:title ;
 .
 
 eden://harvester/fairsharing/https://www.ldc.upenn.edu/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/fairsharing/https://www.ldc.upenn.edu/>"@en .
 
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ldc.upenn.edu/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://www.ldc.upenn.edu/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://www.ldc.upenn.edu/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ldc.upenn.edu/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ldc.upenn.edu/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.ldc.upenn.edu/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://www.ldc.upenn.edu/ ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 eden://harvester/fairsharing/https://www.lipidmaps.org/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/fairsharing/https://www.lipidmaps.org/>"@en .
 
+ex:typeProfile_ex_SustainabilityPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.lipidmaps.org/ ;
+  ex:nodeType <ex:SustainabilityPolicy> ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.lipidmaps.org/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.lipidmaps.org/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://www.lipidmaps.org/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://www.lipidmaps.org/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.lipidmaps.org/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.lipidmaps.org/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.lipidmaps.org/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -1942,53 +5256,131 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+.
+
+ex:typeProfile_premis_PreservationPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.lipidmaps.org/ ;
+  ex:nodeType <premis:PreservationPolicy> ;
+  ex:usesProperty dct:title ;
 .
 
 eden://harvester/fairsharing/https://www.orthodb.org/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/fairsharing/https://www.orthodb.org/>"@en .
 
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.orthodb.org/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://www.orthodb.org/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://www.orthodb.org/ ;
   ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dct:conformsTo ;
-  ex:usesProperty dct:contactPoint ;
-  ex:usesProperty dct:publisher ;
-  ex:usesProperty dcat:service ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.orthodb.org/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.orthodb.org/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.orthodb.org/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://www.orthodb.org/ ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 eden://harvester/fairsharing/https://www.paradisec.org.au/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/fairsharing/https://www.paradisec.org.au/>"@en .
 
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.paradisec.org.au/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://www.paradisec.org.au/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://www.paradisec.org.au/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.paradisec.org.au/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.paradisec.org.au/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.paradisec.org.au/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -1996,26 +5388,63 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 eden://harvester/fairsharing/https://www.rohub.org/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/fairsharing/https://www.rohub.org/>"@en .
 
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.rohub.org/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://www.rohub.org/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://www.rohub.org/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.rohub.org/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.rohub.org/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.rohub.org/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -2023,26 +5452,63 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 eden://harvester/fairsharing/https://www.storedb.org/store_v3/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/fairsharing/https://www.storedb.org/store_v3/>"@en .
 
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.storedb.org/store_v3/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://www.storedb.org/store_v3/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://www.storedb.org/store_v3/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.storedb.org/store_v3/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.storedb.org/store_v3/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.storedb.org/store_v3/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -2050,26 +5516,62 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 eden://harvester/fairsharing/https://www.tarki.hu/eng a ex:NamedGraph ;
   rdfs:label "<eden://harvester/fairsharing/https://www.tarki.hu/eng>"@en .
 
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.tarki.hu/eng ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://www.tarki.hu/eng ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://www.tarki.hu/eng ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.tarki.hu/eng ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.tarki.hu/eng ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.tarki.hu/eng ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -2077,26 +5579,74 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 eden://harvester/fairsharing/https://www.uniprot.org/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/fairsharing/https://www.uniprot.org/>"@en .
 
+ex:typeProfile_ex_SustainabilityPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.uniprot.org/ ;
+  ex:nodeType <ex:SustainabilityPolicy> ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.uniprot.org/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.uniprot.org/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://www.uniprot.org/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://www.uniprot.org/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.uniprot.org/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.uniprot.org/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.uniprot.org/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -2104,26 +5654,68 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+.
+
+ex:typeProfile_premis_PreservationPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.uniprot.org/ ;
+  ex:nodeType <premis:PreservationPolicy> ;
+  ex:usesProperty dct:title ;
 .
 
 eden://harvester/fairsharing/https://www.wdc-climate.de/ui/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/fairsharing/https://www.wdc-climate.de/ui/>"@en .
 
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.wdc-climate.de/ui/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://www.wdc-climate.de/ui/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/fairsharing/https://www.wdc-climate.de/ui/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.wdc-climate.de/ui/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.wdc-climate.de/ui/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/fairsharing/https://www.wdc-climate.de/ui/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -2131,7 +5723,12 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 eden://harvester/feed_services/https://archiv.soc.cas.cz/en/ a ex:NamedGraph ;
@@ -2140,20 +5737,45 @@ eden://harvester/feed_services/https://archiv.soc.cas.cz/en/ a ex:NamedGraph ;
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/feed_services/https://archiv.soc.cas.cz/en/ ;
   ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/feed_services/https://archiv.soc.cas.cz/en/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
 .
 
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/feed_services/https://archiv.soc.cas.cz/en/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:format ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/feed_services/https://archiv.soc.cas.cz/en/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/feed_services/https://archiv.soc.cas.cz/en/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
 ex:typeProfile_Project a ex:TypeProfile ;
   ex:inGraph eden://harvester/feed_services/https://archiv.soc.cas.cz/en/ ;
   ex:nodeType foaf:Project ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dcat:service ;
 .
 
@@ -2163,20 +5785,45 @@ eden://harvester/feed_services/https://cds.unistra.fr/ a ex:NamedGraph ;
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/feed_services/https://cds.unistra.fr/ ;
   ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/feed_services/https://cds.unistra.fr/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
 .
 
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/feed_services/https://cds.unistra.fr/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:format ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/feed_services/https://cds.unistra.fr/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/feed_services/https://cds.unistra.fr/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
 ex:typeProfile_Project a ex:TypeProfile ;
   ex:inGraph eden://harvester/feed_services/https://cds.unistra.fr/ ;
   ex:nodeType foaf:Project ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dcat:service ;
 .
 
@@ -2186,20 +5833,45 @@ eden://harvester/feed_services/https://dans.knaw.nl/nl/life-sciences/ a ex:Named
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/feed_services/https://dans.knaw.nl/nl/life-sciences/ ;
   ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/feed_services/https://dans.knaw.nl/nl/life-sciences/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
 .
 
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/feed_services/https://dans.knaw.nl/nl/life-sciences/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:format ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/feed_services/https://dans.knaw.nl/nl/life-sciences/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/feed_services/https://dans.knaw.nl/nl/life-sciences/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
 ex:typeProfile_Project a ex:TypeProfile ;
   ex:inGraph eden://harvester/feed_services/https://dans.knaw.nl/nl/life-sciences/ ;
   ex:nodeType foaf:Project ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dcat:service ;
 .
 
@@ -2209,20 +5881,45 @@ eden://harvester/feed_services/https://dans.knaw.nl/nl/social-sciences-and-human
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/feed_services/https://dans.knaw.nl/nl/social-sciences-and-humanities/ ;
   ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/feed_services/https://dans.knaw.nl/nl/social-sciences-and-humanities/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
 .
 
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/feed_services/https://dans.knaw.nl/nl/social-sciences-and-humanities/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:format ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/feed_services/https://dans.knaw.nl/nl/social-sciences-and-humanities/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/feed_services/https://dans.knaw.nl/nl/social-sciences-and-humanities/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
 ex:typeProfile_Project a ex:TypeProfile ;
   ex:inGraph eden://harvester/feed_services/https://dans.knaw.nl/nl/social-sciences-and-humanities/ ;
   ex:nodeType foaf:Project ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dcat:service ;
 .
 
@@ -2232,20 +5929,45 @@ eden://harvester/feed_services/https://dass.credi.ba/ a ex:NamedGraph ;
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/feed_services/https://dass.credi.ba/ ;
   ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/feed_services/https://dass.credi.ba/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
 .
 
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/feed_services/https://dass.credi.ba/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:format ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/feed_services/https://dass.credi.ba/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/feed_services/https://dass.credi.ba/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
 ex:typeProfile_Project a ex:TypeProfile ;
   ex:inGraph eden://harvester/feed_services/https://dass.credi.ba/ ;
   ex:nodeType foaf:Project ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dcat:service ;
 .
 
@@ -2255,20 +5977,45 @@ eden://harvester/feed_services/https://library.camtree.org/home a ex:NamedGraph 
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/feed_services/https://library.camtree.org/home ;
   ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/feed_services/https://library.camtree.org/home ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
 .
 
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/feed_services/https://library.camtree.org/home ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:format ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/feed_services/https://library.camtree.org/home ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/feed_services/https://library.camtree.org/home ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
 ex:typeProfile_Project a ex:TypeProfile ;
   ex:inGraph eden://harvester/feed_services/https://library.camtree.org/home ;
   ex:nodeType foaf:Project ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dcat:service ;
 .
 
@@ -2278,20 +6025,45 @@ eden://harvester/feed_services/https://naehrwertdaten.ch/de/ a ex:NamedGraph ;
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/feed_services/https://naehrwertdaten.ch/de/ ;
   ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/feed_services/https://naehrwertdaten.ch/de/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
 .
 
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/feed_services/https://naehrwertdaten.ch/de/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:format ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/feed_services/https://naehrwertdaten.ch/de/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/feed_services/https://naehrwertdaten.ch/de/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
 ex:typeProfile_Project a ex:TypeProfile ;
   ex:inGraph eden://harvester/feed_services/https://naehrwertdaten.ch/de/ ;
   ex:nodeType foaf:Project ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dcat:service ;
 .
 
@@ -2301,20 +6073,45 @@ eden://harvester/feed_services/https://pangaea.de/ a ex:NamedGraph ;
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/feed_services/https://pangaea.de/ ;
   ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/feed_services/https://pangaea.de/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
 .
 
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/feed_services/https://pangaea.de/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:format ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/feed_services/https://pangaea.de/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/feed_services/https://pangaea.de/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
 ex:typeProfile_Project a ex:TypeProfile ;
   ex:inGraph eden://harvester/feed_services/https://pangaea.de/ ;
   ex:nodeType foaf:Project ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dcat:service ;
 .
 
@@ -2324,20 +6121,45 @@ eden://harvester/feed_services/https://portfir.insa.min-saude.pt/pt/ a ex:NamedG
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/feed_services/https://portfir.insa.min-saude.pt/pt/ ;
   ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/feed_services/https://portfir.insa.min-saude.pt/pt/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
 .
 
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/feed_services/https://portfir.insa.min-saude.pt/pt/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:format ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/feed_services/https://portfir.insa.min-saude.pt/pt/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/feed_services/https://portfir.insa.min-saude.pt/pt/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
 ex:typeProfile_Project a ex:TypeProfile ;
   ex:inGraph eden://harvester/feed_services/https://portfir.insa.min-saude.pt/pt/ ;
   ex:nodeType foaf:Project ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dcat:service ;
 .
 
@@ -2347,20 +6169,45 @@ eden://harvester/feed_services/https://reactome.org/ a ex:NamedGraph ;
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/feed_services/https://reactome.org/ ;
   ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/feed_services/https://reactome.org/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
 .
 
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/feed_services/https://reactome.org/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:format ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/feed_services/https://reactome.org/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/feed_services/https://reactome.org/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
 ex:typeProfile_Project a ex:TypeProfile ;
   ex:inGraph eden://harvester/feed_services/https://reactome.org/ ;
   ex:nodeType foaf:Project ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dcat:service ;
 .
 
@@ -2370,20 +6217,45 @@ eden://harvester/feed_services/https://site.uit.no/dataverseno/ a ex:NamedGraph 
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/feed_services/https://site.uit.no/dataverseno/ ;
   ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/feed_services/https://site.uit.no/dataverseno/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
 .
 
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/feed_services/https://site.uit.no/dataverseno/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:format ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/feed_services/https://site.uit.no/dataverseno/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/feed_services/https://site.uit.no/dataverseno/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
 ex:typeProfile_Project a ex:TypeProfile ;
   ex:inGraph eden://harvester/feed_services/https://site.uit.no/dataverseno/ ;
   ex:nodeType foaf:Project ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dcat:service ;
 .
 
@@ -2393,20 +6265,45 @@ eden://harvester/feed_services/https://ukdataservice.ac.uk/about/ a ex:NamedGrap
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/feed_services/https://ukdataservice.ac.uk/about/ ;
   ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/feed_services/https://ukdataservice.ac.uk/about/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
 .
 
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/feed_services/https://ukdataservice.ac.uk/about/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:format ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/feed_services/https://ukdataservice.ac.uk/about/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/feed_services/https://ukdataservice.ac.uk/about/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
 ex:typeProfile_Project a ex:TypeProfile ;
   ex:inGraph eden://harvester/feed_services/https://ukdataservice.ac.uk/about/ ;
   ex:nodeType foaf:Project ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dcat:service ;
 .
 
@@ -2416,20 +6313,45 @@ eden://harvester/feed_services/https://www.adp.fdv.uni-lj.si/ a ex:NamedGraph ;
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/feed_services/https://www.adp.fdv.uni-lj.si/ ;
   ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/feed_services/https://www.adp.fdv.uni-lj.si/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
 .
 
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/feed_services/https://www.adp.fdv.uni-lj.si/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:format ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/feed_services/https://www.adp.fdv.uni-lj.si/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/feed_services/https://www.adp.fdv.uni-lj.si/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
 ex:typeProfile_Project a ex:TypeProfile ;
   ex:inGraph eden://harvester/feed_services/https://www.adp.fdv.uni-lj.si/ ;
   ex:nodeType foaf:Project ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dcat:service ;
 .
 
@@ -2439,20 +6361,45 @@ eden://harvester/feed_services/https://www.crossda.hr/ a ex:NamedGraph ;
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/feed_services/https://www.crossda.hr/ ;
   ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/feed_services/https://www.crossda.hr/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
 .
 
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/feed_services/https://www.crossda.hr/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:format ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/feed_services/https://www.crossda.hr/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/feed_services/https://www.crossda.hr/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
 ex:typeProfile_Project a ex:TypeProfile ;
   ex:inGraph eden://harvester/feed_services/https://www.crossda.hr/ ;
   ex:nodeType foaf:Project ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dcat:service ;
 .
 
@@ -2462,20 +6409,45 @@ eden://harvester/feed_services/https://www.fairdata.fi/ a ex:NamedGraph ;
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/feed_services/https://www.fairdata.fi/ ;
   ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/feed_services/https://www.fairdata.fi/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
 .
 
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/feed_services/https://www.fairdata.fi/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:format ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/feed_services/https://www.fairdata.fi/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/feed_services/https://www.fairdata.fi/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
 ex:typeProfile_Project a ex:TypeProfile ;
   ex:inGraph eden://harvester/feed_services/https://www.fairdata.fi/ ;
   ex:nodeType foaf:Project ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dcat:service ;
 .
 
@@ -2485,20 +6457,45 @@ eden://harvester/feed_services/https://www.kielipankki.fi/language-bank/ a ex:Na
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/feed_services/https://www.kielipankki.fi/language-bank/ ;
   ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/feed_services/https://www.kielipankki.fi/language-bank/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
 .
 
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/feed_services/https://www.kielipankki.fi/language-bank/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:format ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/feed_services/https://www.kielipankki.fi/language-bank/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/feed_services/https://www.kielipankki.fi/language-bank/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
 ex:typeProfile_Project a ex:TypeProfile ;
   ex:inGraph eden://harvester/feed_services/https://www.kielipankki.fi/language-bank/ ;
   ex:nodeType foaf:Project ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dcat:service ;
 .
 
@@ -2508,20 +6505,93 @@ eden://harvester/feed_services/https://www.ortolang.fr/en/home/ a ex:NamedGraph 
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/feed_services/https://www.ortolang.fr/en/home/ ;
   ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/feed_services/https://www.ortolang.fr/en/home/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
 .
 
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/feed_services/https://www.ortolang.fr/en/home/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:format ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/feed_services/https://www.ortolang.fr/en/home/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/feed_services/https://www.ortolang.fr/en/home/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
 ex:typeProfile_Project a ex:TypeProfile ;
   ex:inGraph eden://harvester/feed_services/https://www.ortolang.fr/en/home/ ;
   ex:nodeType foaf:Project ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dcat:service ;
+.
+
+eden://harvester/feed_services/https://www.paradisec.org.au/ a ex:NamedGraph ;
+  rdfs:label "<eden://harvester/feed_services/https://www.paradisec.org.au/>"@en .
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/feed_services/https://www.paradisec.org.au/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dcat:service ;
+.
+
+ex:typeProfile_CatalogRecord a ex:TypeProfile ;
+  ex:inGraph eden://harvester/feed_services/https://www.paradisec.org.au/ ;
+  ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
+  ex:usesProperty prov:wasAssociatedWith ;
+  ex:usesProperty prov:wasGeneratedBy ;
+  ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/feed_services/https://www.paradisec.org.au/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:format ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/feed_services/https://www.paradisec.org.au/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/feed_services/https://www.paradisec.org.au/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/feed_services/https://www.paradisec.org.au/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dcat:service ;
 .
 
@@ -2531,109 +6601,596 @@ eden://harvester/feed_services/https://www.tarki.hu/eng a ex:NamedGraph ;
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/feed_services/https://www.tarki.hu/eng ;
   ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/feed_services/https://www.tarki.hu/eng ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
 .
 
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/feed_services/https://www.tarki.hu/eng ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:format ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/feed_services/https://www.tarki.hu/eng ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/feed_services/https://www.tarki.hu/eng ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
 ex:typeProfile_Project a ex:TypeProfile ;
   ex:inGraph eden://harvester/feed_services/https://www.tarki.hu/eng ;
   ex:nodeType foaf:Project ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dcat:service ;
 .
 
 eden://harvester/harmonized/https://about.coscine.de/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/harmonized/https://about.coscine.de/>"@en .
 
+ex:typeProfile_ex_SustainabilityPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://about.coscine.de/ ;
+  ex:nodeType <ex:SustainabilityPolicy> ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://about.coscine.de/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://about.coscine.de/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://about.coscine.de/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/harmonized/https://about.coscine.de/ ;
   ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dct:conformsTo ;
-  ex:usesProperty dct:contactPoint ;
-  ex:usesProperty dct:publisher ;
-  ex:usesProperty dcat:service ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://about.coscine.de/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://about.coscine.de/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://about.coscine.de/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://about.coscine.de/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://about.coscine.de/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
+ex:typeProfile_premis_PreservationPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://about.coscine.de/ ;
+  ex:nodeType <premis:PreservationPolicy> ;
+  ex:usesProperty dct:title ;
 .
 
 eden://harvester/harmonized/https://agroportal.eu/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/harmonized/https://agroportal.eu/>"@en .
 
+ex:typeProfile_ex_SustainabilityPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://agroportal.eu/ ;
+  ex:nodeType <ex:SustainabilityPolicy> ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://agroportal.eu/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://agroportal.eu/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+  ex:usesProperty vcard:url ;
+.
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://agroportal.eu/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/harmonized/https://agroportal.eu/ ;
   ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dct:conformsTo ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://agroportal.eu/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://agroportal.eu/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://agroportal.eu/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://agroportal.eu/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://agroportal.eu/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
 .
 
 eden://harvester/harmonized/https://anc.plus.ac.at/index.html a ex:NamedGraph ;
   rdfs:label "<eden://harvester/harmonized/https://anc.plus.ac.at/index.html>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://anc.plus.ac.at/index.html ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://anc.plus.ac.at/index.html ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://anc.plus.ac.at/index.html ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:language ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/harmonized/https://anc.plus.ac.at/index.html ;
   ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dct:conformsTo ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://anc.plus.ac.at/index.html ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://anc.plus.ac.at/index.html ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://anc.plus.ac.at/index.html ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://anc.plus.ac.at/index.html ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://anc.plus.ac.at/index.html ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:language ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
+ex:typeProfile_premis_PreservationPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://anc.plus.ac.at/index.html ;
+  ex:nodeType <premis:PreservationPolicy> ;
+  ex:usesProperty dct:title ;
 .
 
 eden://harvester/harmonized/https://archiv.soc.cas.cz/en/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/harmonized/https://archiv.soc.cas.cz/en/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://archiv.soc.cas.cz/en/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://archiv.soc.cas.cz/en/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://archiv.soc.cas.cz/en/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/harmonized/https://archiv.soc.cas.cz/en/ ;
   ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dct:conformsTo ;
-  ex:usesProperty dct:contactPoint ;
-  ex:usesProperty dct:publisher ;
-  ex:usesProperty dcat:service ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://archiv.soc.cas.cz/en/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://archiv.soc.cas.cz/en/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://archiv.soc.cas.cz/en/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://archiv.soc.cas.cz/en/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://archiv.soc.cas.cz/en/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
 .
 
 eden://harvester/harmonized/https://aussda.at/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/harmonized/https://aussda.at/>"@en .
 
+ex:typeProfile_ex_SustainabilityPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://aussda.at/ ;
+  ex:nodeType <ex:SustainabilityPolicy> ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://aussda.at/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://aussda.at/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://aussda.at/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/harmonized/https://aussda.at/ ;
   ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dct:conformsTo ;
-  ex:usesProperty dct:contactPoint ;
-  ex:usesProperty dct:publisher ;
-  ex:usesProperty dcat:service ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://aussda.at/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://aussda.at/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://aussda.at/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://aussda.at/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://aussda.at/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
+ex:typeProfile_premis_PreservationPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://aussda.at/ ;
+  ex:nodeType <premis:PreservationPolicy> ;
+  ex:usesProperty dct:title ;
 .
 
 eden://harvester/harmonized/https://bacdive.dsmz.de/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/harmonized/https://bacdive.dsmz.de/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://bacdive.dsmz.de/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://bacdive.dsmz.de/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+  ex:usesProperty vcard:url ;
+.
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://bacdive.dsmz.de/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/harmonized/https://bacdive.dsmz.de/ ;
   ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dct:conformsTo ;
-  ex:usesProperty dct:contactPoint ;
-  ex:usesProperty dct:publisher ;
-  ex:usesProperty dcat:service ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
 .
 
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://bacdive.dsmz.de/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://bacdive.dsmz.de/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://bacdive.dsmz.de/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://bacdive.dsmz.de/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://bacdive.dsmz.de/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
 eden://harvester/harmonized/https://biomodels.org/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/harmonized/https://biomodels.org/>"@en .
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://biomodels.org/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/harmonized/https://biomodels.org/ ;
@@ -2643,1069 +7200,6617 @@ ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:usesProperty foaf:primaryTopic ;
 .
 
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://biomodels.org/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://biomodels.org/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://biomodels.org/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
 eden://harvester/harmonized/https://borealisdata.ca/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/harmonized/https://borealisdata.ca/>"@en .
+
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://borealisdata.ca/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://borealisdata.ca/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://borealisdata.ca/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/harmonized/https://borealisdata.ca/ ;
   ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dct:conformsTo ;
-  ex:usesProperty dct:contactPoint ;
-  ex:usesProperty dct:publisher ;
-  ex:usesProperty dcat:service ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
-  ex:usesProperty foaf:homepage ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://borealisdata.ca/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://borealisdata.ca/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://borealisdata.ca/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://borealisdata.ca/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://borealisdata.ca/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
+ex:typeProfile_premis_PreservationPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://borealisdata.ca/ ;
+  ex:nodeType <premis:PreservationPolicy> ;
+  ex:usesProperty dct:title ;
 .
 
 eden://harvester/harmonized/https://cds.climate.copernicus.eu/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/harmonized/https://cds.climate.copernicus.eu/>"@en .
 
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://cds.climate.copernicus.eu/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://cds.climate.copernicus.eu/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/harmonized/https://cds.climate.copernicus.eu/ ;
   ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dct:contactPoint ;
-  ex:usesProperty dct:publisher ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://cds.climate.copernicus.eu/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://cds.climate.copernicus.eu/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://cds.climate.copernicus.eu/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty foaf:name ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://cds.climate.copernicus.eu/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty prov:hadPrimarySource ;
 .
 
 eden://harvester/harmonized/https://cds.unistra.fr/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/harmonized/https://cds.unistra.fr/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://cds.unistra.fr/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://cds.unistra.fr/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://cds.unistra.fr/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/harmonized/https://cds.unistra.fr/ ;
   ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dct:conformsTo ;
-  ex:usesProperty dct:contactPoint ;
-  ex:usesProperty dct:publisher ;
-  ex:usesProperty dcat:service ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://cds.unistra.fr/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://cds.unistra.fr/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://cds.unistra.fr/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://cds.unistra.fr/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://cds.unistra.fr/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
 .
 
 eden://harvester/harmonized/https://cer.ihtm.bg.ac.rs/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/harmonized/https://cer.ihtm.bg.ac.rs/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://cer.ihtm.bg.ac.rs/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://cer.ihtm.bg.ac.rs/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://cer.ihtm.bg.ac.rs/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/harmonized/https://cer.ihtm.bg.ac.rs/ ;
   ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dct:conformsTo ;
-  ex:usesProperty dct:contactPoint ;
-  ex:usesProperty dct:publisher ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://cer.ihtm.bg.ac.rs/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://cer.ihtm.bg.ac.rs/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://cer.ihtm.bg.ac.rs/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://cer.ihtm.bg.ac.rs/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty prov:hadPrimarySource ;
 .
 
 eden://harvester/harmonized/https://dais.sanu.ac.rs/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/harmonized/https://dais.sanu.ac.rs/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://dais.sanu.ac.rs/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://dais.sanu.ac.rs/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+  ex:usesProperty vcard:url ;
+.
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://dais.sanu.ac.rs/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/harmonized/https://dais.sanu.ac.rs/ ;
   ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dct:conformsTo ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://dais.sanu.ac.rs/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://dais.sanu.ac.rs/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://dais.sanu.ac.rs/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://dais.sanu.ac.rs/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty prov:hadPrimarySource ;
 .
 
 eden://harvester/harmonized/https://dans.knaw.nl/nl/life-sciences/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/harmonized/https://dans.knaw.nl/nl/life-sciences/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://dans.knaw.nl/nl/life-sciences/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://dans.knaw.nl/nl/life-sciences/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://dans.knaw.nl/nl/life-sciences/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:language ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/harmonized/https://dans.knaw.nl/nl/life-sciences/ ;
   ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dct:conformsTo ;
-  ex:usesProperty dct:contactPoint ;
-  ex:usesProperty dct:publisher ;
-  ex:usesProperty dcat:service ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://dans.knaw.nl/nl/life-sciences/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://dans.knaw.nl/nl/life-sciences/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://dans.knaw.nl/nl/life-sciences/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://dans.knaw.nl/nl/life-sciences/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://dans.knaw.nl/nl/life-sciences/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:language ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
 .
 
 eden://harvester/harmonized/https://dans.knaw.nl/nl/social-sciences-and-humanities/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/harmonized/https://dans.knaw.nl/nl/social-sciences-and-humanities/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://dans.knaw.nl/nl/social-sciences-and-humanities/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://dans.knaw.nl/nl/social-sciences-and-humanities/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://dans.knaw.nl/nl/social-sciences-and-humanities/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:language ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/harmonized/https://dans.knaw.nl/nl/social-sciences-and-humanities/ ;
   ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dct:conformsTo ;
-  ex:usesProperty dct:contactPoint ;
-  ex:usesProperty dct:publisher ;
-  ex:usesProperty dcat:service ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://dans.knaw.nl/nl/social-sciences-and-humanities/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://dans.knaw.nl/nl/social-sciences-and-humanities/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://dans.knaw.nl/nl/social-sciences-and-humanities/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://dans.knaw.nl/nl/social-sciences-and-humanities/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://dans.knaw.nl/nl/social-sciences-and-humanities/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:language ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
 .
 
 eden://harvester/harmonized/https://dass.credi.ba/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/harmonized/https://dass.credi.ba/>"@en .
 
+ex:typeProfile_ex_SustainabilityPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://dass.credi.ba/ ;
+  ex:nodeType <ex:SustainabilityPolicy> ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://dass.credi.ba/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://dass.credi.ba/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+  ex:usesProperty vcard:url ;
+.
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://dass.credi.ba/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/harmonized/https://dass.credi.ba/ ;
   ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dct:conformsTo ;
-  ex:usesProperty dct:contactPoint ;
-  ex:usesProperty dct:publisher ;
-  ex:usesProperty dcat:service ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://dass.credi.ba/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://dass.credi.ba/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://dass.credi.ba/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://dass.credi.ba/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://dass.credi.ba/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
+ex:typeProfile_premis_PreservationPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://dass.credi.ba/ ;
+  ex:nodeType <premis:PreservationPolicy> ;
+  ex:usesProperty dct:title ;
 .
 
 eden://harvester/harmonized/https://data.4tu.nl/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/harmonized/https://data.4tu.nl/>"@en .
 
+ex:typeProfile_ex_SustainabilityPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://data.4tu.nl/ ;
+  ex:nodeType <ex:SustainabilityPolicy> ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://data.4tu.nl/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://data.4tu.nl/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+  ex:usesProperty vcard:url ;
+.
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://data.4tu.nl/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/harmonized/https://data.4tu.nl/ ;
   ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dct:conformsTo ;
-  ex:usesProperty dct:contactPoint ;
-  ex:usesProperty dct:publisher ;
-  ex:usesProperty dcat:service ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://data.4tu.nl/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://data.4tu.nl/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://data.4tu.nl/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://data.4tu.nl/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://data.4tu.nl/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
+ex:typeProfile_premis_PreservationPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://data.4tu.nl/ ;
+  ex:nodeType <premis:PreservationPolicy> ;
+  ex:usesProperty dct:title ;
 .
 
 eden://harvester/harmonized/https://data.dtu.dk/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/harmonized/https://data.dtu.dk/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://data.dtu.dk/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://data.dtu.dk/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+  ex:usesProperty vcard:url ;
+.
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://data.dtu.dk/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/harmonized/https://data.dtu.dk/ ;
   ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dct:conformsTo ;
-  ex:usesProperty dct:contactPoint ;
-  ex:usesProperty dct:publisher ;
-  ex:usesProperty dcat:service ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://data.dtu.dk/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://data.dtu.dk/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://data.dtu.dk/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://data.dtu.dk/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://data.dtu.dk/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
 .
 
 eden://harvester/harmonized/https://data.progedo.fr/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/harmonized/https://data.progedo.fr/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://data.progedo.fr/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://data.progedo.fr/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+  ex:usesProperty vcard:url ;
+.
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://data.progedo.fr/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/harmonized/https://data.progedo.fr/ ;
   ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dct:conformsTo ;
-  ex:usesProperty dct:publisher ;
-  ex:usesProperty dcat:service ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://data.progedo.fr/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://data.progedo.fr/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://data.progedo.fr/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://data.progedo.fr/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://data.progedo.fr/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
 .
 
 eden://harvester/harmonized/https://data.sciencespo.fr/dataverse/cdsp a ex:NamedGraph ;
   rdfs:label "<eden://harvester/harmonized/https://data.sciencespo.fr/dataverse/cdsp>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://data.sciencespo.fr/dataverse/cdsp ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://data.sciencespo.fr/dataverse/cdsp ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://data.sciencespo.fr/dataverse/cdsp ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/harmonized/https://data.sciencespo.fr/dataverse/cdsp ;
   ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dct:conformsTo ;
-  ex:usesProperty dct:contactPoint ;
-  ex:usesProperty dct:publisher ;
-  ex:usesProperty dcat:service ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://data.sciencespo.fr/dataverse/cdsp ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://data.sciencespo.fr/dataverse/cdsp ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://data.sciencespo.fr/dataverse/cdsp ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://data.sciencespo.fr/dataverse/cdsp ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://data.sciencespo.fr/dataverse/cdsp ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
 .
 
 eden://harvester/harmonized/https://datarepositorium.uminho.pt/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/harmonized/https://datarepositorium.uminho.pt/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://datarepositorium.uminho.pt/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://datarepositorium.uminho.pt/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://datarepositorium.uminho.pt/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/harmonized/https://datarepositorium.uminho.pt/ ;
   ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dct:conformsTo ;
-  ex:usesProperty dct:contactPoint ;
-  ex:usesProperty dct:publisher ;
-  ex:usesProperty dcat:service ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://datarepositorium.uminho.pt/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://datarepositorium.uminho.pt/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://datarepositorium.uminho.pt/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://datarepositorium.uminho.pt/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://datarepositorium.uminho.pt/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
 .
 
 eden://harvester/harmonized/https://dataservices.gfz-potsdam.de/web/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/harmonized/https://dataservices.gfz-potsdam.de/web/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://dataservices.gfz-potsdam.de/web/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://dataservices.gfz-potsdam.de/web/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+  ex:usesProperty vcard:url ;
+.
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://dataservices.gfz-potsdam.de/web/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/harmonized/https://dataservices.gfz-potsdam.de/web/ ;
   ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dct:conformsTo ;
-  ex:usesProperty dct:contactPoint ;
-  ex:usesProperty dct:publisher ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://dataservices.gfz-potsdam.de/web/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://dataservices.gfz-potsdam.de/web/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://dataservices.gfz-potsdam.de/web/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://dataservices.gfz-potsdam.de/web/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
+eden://harvester/harmonized/https://dataverse.no/dataverse/trolling a ex:NamedGraph ;
+  rdfs:label "<eden://harvester/harmonized/https://dataverse.no/dataverse/trolling>"@en .
+
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://dataverse.no/dataverse/trolling ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://dataverse.no/dataverse/trolling ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+  ex:usesProperty vcard:url ;
+.
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://dataverse.no/dataverse/trolling ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
+ex:typeProfile_CatalogRecord a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://dataverse.no/dataverse/trolling ;
+  ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty prov:wasAssociatedWith ;
+  ex:usesProperty prov:wasGeneratedBy ;
+  ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://dataverse.no/dataverse/trolling ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://dataverse.no/dataverse/trolling ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://dataverse.no/dataverse/trolling ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://dataverse.no/dataverse/trolling ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://dataverse.no/dataverse/trolling ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
+ex:typeProfile_premis_PreservationPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://dataverse.no/dataverse/trolling ;
+  ex:nodeType <premis:PreservationPolicy> ;
+  ex:usesProperty dct:title ;
 .
 
 eden://harvester/harmonized/https://datice.is/is a ex:NamedGraph ;
   rdfs:label "<eden://harvester/harmonized/https://datice.is/is>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://datice.is/is ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://datice.is/is ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://datice.is/is ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/harmonized/https://datice.is/is ;
   ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dct:conformsTo ;
-  ex:usesProperty dct:contactPoint ;
-  ex:usesProperty dct:publisher ;
-  ex:usesProperty dcat:service ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://datice.is/is ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://datice.is/is ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://datice.is/is ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://datice.is/is ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://datice.is/is ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
 .
 
 eden://harvester/harmonized/https://dv.dataverse.lv/dataverse/root a ex:NamedGraph ;
   rdfs:label "<eden://harvester/harmonized/https://dv.dataverse.lv/dataverse/root>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://dv.dataverse.lv/dataverse/root ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://dv.dataverse.lv/dataverse/root ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://dv.dataverse.lv/dataverse/root ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/harmonized/https://dv.dataverse.lv/dataverse/root ;
   ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dct:conformsTo ;
-  ex:usesProperty dct:contactPoint ;
-  ex:usesProperty dct:publisher ;
-  ex:usesProperty dcat:service ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://dv.dataverse.lv/dataverse/root ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://dv.dataverse.lv/dataverse/root ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://dv.dataverse.lv/dataverse/root ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://dv.dataverse.lv/dataverse/root ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://dv.dataverse.lv/dataverse/root ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
 .
 
 eden://harvester/harmonized/https://ega-archive.org/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/harmonized/https://ega-archive.org/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://ega-archive.org/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://ega-archive.org/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:url ;
+.
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://ega-archive.org/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/harmonized/https://ega-archive.org/ ;
   ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dct:conformsTo ;
-  ex:usesProperty dct:contactPoint ;
-  ex:usesProperty dct:publisher ;
-  ex:usesProperty dcat:service ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://ega-archive.org/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://ega-archive.org/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://ega-archive.org/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://ega-archive.org/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://ega-archive.org/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
 .
 
 eden://harvester/harmonized/https://glittr.org/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/harmonized/https://glittr.org/>"@en .
 
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://glittr.org/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://glittr.org/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/harmonized/https://glittr.org/ ;
   ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dct:contactPoint ;
-  ex:usesProperty dct:publisher ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://glittr.org/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://glittr.org/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://glittr.org/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty foaf:name ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://glittr.org/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty prov:hadPrimarySource ;
 .
 
 eden://harvester/harmonized/https://gude.uni-frankfurt.de/home a ex:NamedGraph ;
   rdfs:label "<eden://harvester/harmonized/https://gude.uni-frankfurt.de/home>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://gude.uni-frankfurt.de/home ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://gude.uni-frankfurt.de/home ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+  ex:usesProperty vcard:url ;
+.
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://gude.uni-frankfurt.de/home ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/harmonized/https://gude.uni-frankfurt.de/home ;
   ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dct:conformsTo ;
-  ex:usesProperty dct:contactPoint ;
-  ex:usesProperty dct:publisher ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://gude.uni-frankfurt.de/home ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://gude.uni-frankfurt.de/home ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://gude.uni-frankfurt.de/home ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://gude.uni-frankfurt.de/home ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty prov:hadPrimarySource ;
 .
 
 eden://harvester/harmonized/https://inspirehep.net/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/harmonized/https://inspirehep.net/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://inspirehep.net/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://inspirehep.net/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+  ex:usesProperty vcard:url ;
+.
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://inspirehep.net/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/harmonized/https://inspirehep.net/ ;
   ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dct:conformsTo ;
-  ex:usesProperty dct:contactPoint ;
-  ex:usesProperty dct:publisher ;
-  ex:usesProperty dcat:service ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://inspirehep.net/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://inspirehep.net/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://inspirehep.net/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://inspirehep.net/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://inspirehep.net/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
 .
 
 eden://harvester/harmonized/https://library.camtree.org/home a ex:NamedGraph ;
   rdfs:label "<eden://harvester/harmonized/https://library.camtree.org/home>"@en .
 
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://library.camtree.org/home ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/harmonized/https://library.camtree.org/home ;
   ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dcat:service ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://library.camtree.org/home ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://library.camtree.org/home ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://library.camtree.org/home ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://library.camtree.org/home ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
 .
 
 eden://harvester/harmonized/https://lida.dataverse.lt/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/harmonized/https://lida.dataverse.lt/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://lida.dataverse.lt/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://lida.dataverse.lt/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+  ex:usesProperty vcard:url ;
+.
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://lida.dataverse.lt/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/harmonized/https://lida.dataverse.lt/ ;
   ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dct:conformsTo ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://lida.dataverse.lt/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://lida.dataverse.lt/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://lida.dataverse.lt/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://lida.dataverse.lt/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://lida.dataverse.lt/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
 .
 
 eden://harvester/harmonized/https://lindat.mff.cuni.cz/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/harmonized/https://lindat.mff.cuni.cz/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://lindat.mff.cuni.cz/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://lindat.mff.cuni.cz/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://lindat.mff.cuni.cz/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/harmonized/https://lindat.mff.cuni.cz/ ;
   ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dct:conformsTo ;
-  ex:usesProperty dct:contactPoint ;
-  ex:usesProperty dct:publisher ;
-  ex:usesProperty dcat:service ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
-  ex:usesProperty foaf:homepage ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://lindat.mff.cuni.cz/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://lindat.mff.cuni.cz/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://lindat.mff.cuni.cz/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://lindat.mff.cuni.cz/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://lindat.mff.cuni.cz/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
 .
 
 eden://harvester/harmonized/https://modelarchive.org/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/harmonized/https://modelarchive.org/>"@en .
 
+ex:typeProfile_CreativeWork a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://modelarchive.org/ ;
+  ex:nodeType <http://localhost:3030/service_registry_store/CreativeWork> ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_license a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://modelarchive.org/ ;
+  ex:nodeType <http://localhost:3030/service_registry_store/license> ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://modelarchive.org/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://modelarchive.org/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://modelarchive.org/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/harmonized/https://modelarchive.org/ ;
   ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dct:conformsTo ;
-  ex:usesProperty dct:contactPoint ;
-  ex:usesProperty dct:publisher ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://modelarchive.org/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://modelarchive.org/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://modelarchive.org/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://modelarchive.org/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty prov:hadPrimarySource ;
 .
 
 eden://harvester/harmonized/https://naehrwertdaten.ch/de/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/harmonized/https://naehrwertdaten.ch/de/>"@en .
 
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://naehrwertdaten.ch/de/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:language ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/harmonized/https://naehrwertdaten.ch/de/ ;
   ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dcat:service ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://naehrwertdaten.ch/de/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://naehrwertdaten.ch/de/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://naehrwertdaten.ch/de/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://naehrwertdaten.ch/de/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:language ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
+eden://harvester/harmonized/https://omabrowser.org/oma/home/ a ex:NamedGraph ;
+  rdfs:label "<eden://harvester/harmonized/https://omabrowser.org/oma/home/>"@en .
+
+ex:typeProfile_CreativeWork a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://omabrowser.org/oma/home/ ;
+  ex:nodeType <http://localhost:3030/service_registry_store/CreativeWork> ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_license a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://omabrowser.org/oma/home/ ;
+  ex:nodeType <http://localhost:3030/service_registry_store/license> ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://omabrowser.org/oma/home/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://omabrowser.org/oma/home/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://omabrowser.org/oma/home/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
+ex:typeProfile_CatalogRecord a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://omabrowser.org/oma/home/ ;
+  ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty prov:wasAssociatedWith ;
+  ex:usesProperty prov:wasGeneratedBy ;
+  ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://omabrowser.org/oma/home/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://omabrowser.org/oma/home/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://omabrowser.org/oma/home/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://omabrowser.org/oma/home/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty foaf:name ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://omabrowser.org/oma/home/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
 .
 
 eden://harvester/harmonized/https://opendata.nas.gov.ua/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/harmonized/https://opendata.nas.gov.ua/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://opendata.nas.gov.ua/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://opendata.nas.gov.ua/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://opendata.nas.gov.ua/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/harmonized/https://opendata.nas.gov.ua/ ;
   ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dct:conformsTo ;
-  ex:usesProperty dct:contactPoint ;
-  ex:usesProperty dct:publisher ;
-  ex:usesProperty dcat:service ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://opendata.nas.gov.ua/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://opendata.nas.gov.ua/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://opendata.nas.gov.ua/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://opendata.nas.gov.ua/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://opendata.nas.gov.ua/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
 .
 
 eden://harvester/harmonized/https://pangaea.de/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/harmonized/https://pangaea.de/>"@en .
 
+ex:typeProfile_ex_SustainabilityPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://pangaea.de/ ;
+  ex:nodeType <ex:SustainabilityPolicy> ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://pangaea.de/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://pangaea.de/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+  ex:usesProperty vcard:url ;
+.
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://pangaea.de/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:language ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/harmonized/https://pangaea.de/ ;
   ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dct:conformsTo ;
-  ex:usesProperty dct:contactPoint ;
-  ex:usesProperty dct:publisher ;
-  ex:usesProperty dcat:service ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://pangaea.de/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://pangaea.de/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://pangaea.de/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://pangaea.de/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://pangaea.de/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:language ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
+ex:typeProfile_premis_PreservationPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://pangaea.de/ ;
+  ex:nodeType <premis:PreservationPolicy> ;
+  ex:usesProperty dct:title ;
 .
 
 eden://harvester/harmonized/https://portfir.insa.min-saude.pt/pt/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/harmonized/https://portfir.insa.min-saude.pt/pt/>"@en .
 
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://portfir.insa.min-saude.pt/pt/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/harmonized/https://portfir.insa.min-saude.pt/pt/ ;
   ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dcat:service ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://portfir.insa.min-saude.pt/pt/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://portfir.insa.min-saude.pt/pt/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://portfir.insa.min-saude.pt/pt/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://portfir.insa.min-saude.pt/pt/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
 .
 
 eden://harvester/harmonized/https://qdr.syr.edu/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/harmonized/https://qdr.syr.edu/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://qdr.syr.edu/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://qdr.syr.edu/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+  ex:usesProperty vcard:url ;
+.
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://qdr.syr.edu/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/harmonized/https://qdr.syr.edu/ ;
   ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dct:conformsTo ;
-  ex:usesProperty dct:contactPoint ;
-  ex:usesProperty dct:publisher ;
-  ex:usesProperty dcat:service ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://qdr.syr.edu/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://qdr.syr.edu/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://qdr.syr.edu/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://qdr.syr.edu/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://qdr.syr.edu/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
+ex:typeProfile_premis_PreservationPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://qdr.syr.edu/ ;
+  ex:nodeType <premis:PreservationPolicy> ;
+  ex:usesProperty dct:title ;
 .
 
 eden://harvester/harmonized/https://radar.brookes.ac.uk/radar/hierarchy.do?topic=86e2c9d7-ef43-4b54-a387-3223d30acd3b a ex:NamedGraph ;
   rdfs:label "<eden://harvester/harmonized/https://radar.brookes.ac.uk/radar/hierarchy.do?topic=86e2c9d7-ef43-4b54-a387-3223d30acd3b>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://radar.brookes.ac.uk/radar/hierarchy.do?topic=86e2c9d7-ef43-4b54-a387-3223d30acd3b ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://radar.brookes.ac.uk/radar/hierarchy.do?topic=86e2c9d7-ef43-4b54-a387-3223d30acd3b ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+  ex:usesProperty vcard:url ;
+.
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://radar.brookes.ac.uk/radar/hierarchy.do?topic=86e2c9d7-ef43-4b54-a387-3223d30acd3b ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/harmonized/https://radar.brookes.ac.uk/radar/hierarchy.do?topic=86e2c9d7-ef43-4b54-a387-3223d30acd3b ;
   ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dct:conformsTo ;
-  ex:usesProperty dct:contactPoint ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://radar.brookes.ac.uk/radar/hierarchy.do?topic=86e2c9d7-ef43-4b54-a387-3223d30acd3b ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://radar.brookes.ac.uk/radar/hierarchy.do?topic=86e2c9d7-ef43-4b54-a387-3223d30acd3b ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://radar.brookes.ac.uk/radar/hierarchy.do?topic=86e2c9d7-ef43-4b54-a387-3223d30acd3b ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://radar.brookes.ac.uk/radar/hierarchy.do?topic=86e2c9d7-ef43-4b54-a387-3223d30acd3b ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://radar.brookes.ac.uk/radar/hierarchy.do?topic=86e2c9d7-ef43-4b54-a387-3223d30acd3b ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
 .
 
 eden://harvester/harmonized/https://radar.ibiss.bg.ac.rs/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/harmonized/https://radar.ibiss.bg.ac.rs/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://radar.ibiss.bg.ac.rs/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://radar.ibiss.bg.ac.rs/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://radar.ibiss.bg.ac.rs/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/harmonized/https://radar.ibiss.bg.ac.rs/ ;
   ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dct:conformsTo ;
-  ex:usesProperty dct:contactPoint ;
-  ex:usesProperty dct:publisher ;
-  ex:usesProperty dcat:service ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://radar.ibiss.bg.ac.rs/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://radar.ibiss.bg.ac.rs/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://radar.ibiss.bg.ac.rs/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://radar.ibiss.bg.ac.rs/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://radar.ibiss.bg.ac.rs/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
 .
 
 eden://harvester/harmonized/https://rdr.kuleuven.be/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/harmonized/https://rdr.kuleuven.be/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://rdr.kuleuven.be/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://rdr.kuleuven.be/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://rdr.kuleuven.be/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/harmonized/https://rdr.kuleuven.be/ ;
   ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dct:conformsTo ;
-  ex:usesProperty dct:contactPoint ;
-  ex:usesProperty dct:publisher ;
-  ex:usesProperty dcat:service ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://rdr.kuleuven.be/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://rdr.kuleuven.be/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://rdr.kuleuven.be/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://rdr.kuleuven.be/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://rdr.kuleuven.be/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
+ex:typeProfile_premis_PreservationPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://rdr.kuleuven.be/ ;
+  ex:nodeType <premis:PreservationPolicy> ;
+  ex:usesProperty dct:title ;
 .
 
 eden://harvester/harmonized/https://reactome.org/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/harmonized/https://reactome.org/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://reactome.org/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://reactome.org/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+  ex:usesProperty vcard:url ;
+.
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://reactome.org/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/harmonized/https://reactome.org/ ;
   ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dct:conformsTo ;
-  ex:usesProperty dct:contactPoint ;
-  ex:usesProperty dct:publisher ;
-  ex:usesProperty dcat:service ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://reactome.org/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://reactome.org/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://reactome.org/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://reactome.org/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://reactome.org/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
+ex:typeProfile_premis_PreservationPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://reactome.org/ ;
+  ex:nodeType <premis:PreservationPolicy> ;
+  ex:usesProperty dct:title ;
+.
+
+eden://harvester/harmonized/https://recherche.data.gouv.fr/en/page/about-recherche-data-gouv a ex:NamedGraph ;
+  rdfs:label "<eden://harvester/harmonized/https://recherche.data.gouv.fr/en/page/about-recherche-data-gouv>"@en .
+
+ex:typeProfile_ex_DepositionPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://recherche.data.gouv.fr/en/page/about-recherche-data-gouv ;
+  ex:nodeType <ex:DepositionPolicy> ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://recherche.data.gouv.fr/en/page/about-recherche-data-gouv ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://recherche.data.gouv.fr/en/page/about-recherche-data-gouv ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:url ;
+.
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://recherche.data.gouv.fr/en/page/about-recherche-data-gouv ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
+ex:typeProfile_CatalogRecord a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://recherche.data.gouv.fr/en/page/about-recherche-data-gouv ;
+  ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty prov:wasAssociatedWith ;
+  ex:usesProperty prov:wasGeneratedBy ;
+  ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://recherche.data.gouv.fr/en/page/about-recherche-data-gouv ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://recherche.data.gouv.fr/en/page/about-recherche-data-gouv ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://recherche.data.gouv.fr/en/page/about-recherche-data-gouv ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://recherche.data.gouv.fr/en/page/about-recherche-data-gouv ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://recherche.data.gouv.fr/en/page/about-recherche-data-gouv ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
 .
 
 eden://harvester/harmonized/https://repo.researchdata.hu/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/harmonized/https://repo.researchdata.hu/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://repo.researchdata.hu/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://repo.researchdata.hu/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://repo.researchdata.hu/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/harmonized/https://repo.researchdata.hu/ ;
   ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dct:conformsTo ;
-  ex:usesProperty dct:contactPoint ;
-  ex:usesProperty dct:publisher ;
-  ex:usesProperty dcat:service ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://repo.researchdata.hu/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://repo.researchdata.hu/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://repo.researchdata.hu/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://repo.researchdata.hu/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://repo.researchdata.hu/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
 .
 
 eden://harvester/harmonized/https://rivec.institut-palanka.rs/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/harmonized/https://rivec.institut-palanka.rs/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://rivec.institut-palanka.rs/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://rivec.institut-palanka.rs/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+  ex:usesProperty vcard:url ;
+.
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://rivec.institut-palanka.rs/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/harmonized/https://rivec.institut-palanka.rs/ ;
   ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dct:conformsTo ;
-  ex:usesProperty dct:contactPoint ;
-  ex:usesProperty dct:publisher ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://rivec.institut-palanka.rs/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://rivec.institut-palanka.rs/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://rivec.institut-palanka.rs/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://rivec.institut-palanka.rs/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty prov:hadPrimarySource ;
 .
 
 eden://harvester/harmonized/https://sasd.sav.sk/en/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/harmonized/https://sasd.sav.sk/en/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://sasd.sav.sk/en/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://sasd.sav.sk/en/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:url ;
+.
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://sasd.sav.sk/en/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/harmonized/https://sasd.sav.sk/en/ ;
   ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dct:conformsTo ;
-  ex:usesProperty dct:contactPoint ;
-  ex:usesProperty dct:publisher ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://sasd.sav.sk/en/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://sasd.sav.sk/en/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://sasd.sav.sk/en/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://sasd.sav.sk/en/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty prov:hadPrimarySource ;
 .
 
 eden://harvester/harmonized/https://sikt.no/en/archiving-research-data a ex:NamedGraph ;
   rdfs:label "<eden://harvester/harmonized/https://sikt.no/en/archiving-research-data>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://sikt.no/en/archiving-research-data ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://sikt.no/en/archiving-research-data ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+  ex:usesProperty vcard:url ;
+.
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://sikt.no/en/archiving-research-data ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/harmonized/https://sikt.no/en/archiving-research-data ;
   ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dct:conformsTo ;
-  ex:usesProperty dct:contactPoint ;
-  ex:usesProperty dct:publisher ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://sikt.no/en/archiving-research-data ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://sikt.no/en/archiving-research-data ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://sikt.no/en/archiving-research-data ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://sikt.no/en/archiving-research-data ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty prov:hadPrimarySource ;
 .
 
 eden://harvester/harmonized/https://site.uit.no/dataverseno/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/harmonized/https://site.uit.no/dataverseno/>"@en .
 
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://site.uit.no/dataverseno/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/harmonized/https://site.uit.no/dataverseno/ ;
   ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dcat:service ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://site.uit.no/dataverseno/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://site.uit.no/dataverseno/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://site.uit.no/dataverseno/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://site.uit.no/dataverseno/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
 .
 
 eden://harvester/harmonized/https://string-db.org/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/harmonized/https://string-db.org/>"@en .
 
+ex:typeProfile_CreativeWork a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://string-db.org/ ;
+  ex:nodeType <http://localhost:3030/service_registry_store/CreativeWork> ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_license a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://string-db.org/ ;
+  ex:nodeType <http://localhost:3030/service_registry_store/license> ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://string-db.org/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://string-db.org/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:url ;
+.
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://string-db.org/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/harmonized/https://string-db.org/ ;
   ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dct:conformsTo ;
-  ex:usesProperty dct:contactPoint ;
-  ex:usesProperty dct:publisher ;
-  ex:usesProperty dcat:service ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://string-db.org/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://string-db.org/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://string-db.org/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://string-db.org/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://string-db.org/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
 .
 
 eden://harvester/harmonized/https://ukdataservice.ac.uk/about/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/harmonized/https://ukdataservice.ac.uk/about/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://ukdataservice.ac.uk/about/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://ukdataservice.ac.uk/about/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:url ;
+.
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://ukdataservice.ac.uk/about/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:language ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/harmonized/https://ukdataservice.ac.uk/about/ ;
   ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dct:conformsTo ;
-  ex:usesProperty dct:contactPoint ;
-  ex:usesProperty dct:publisher ;
-  ex:usesProperty dcat:service ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://ukdataservice.ac.uk/about/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://ukdataservice.ac.uk/about/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://ukdataservice.ac.uk/about/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://ukdataservice.ac.uk/about/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://ukdataservice.ac.uk/about/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:language ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
+ex:typeProfile_premis_PreservationPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://ukdataservice.ac.uk/about/ ;
+  ex:nodeType <premis:PreservationPolicy> ;
+  ex:usesProperty dct:title ;
 .
 
 eden://harvester/harmonized/https://www.adp.fdv.uni-lj.si/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/harmonized/https://www.adp.fdv.uni-lj.si/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.adp.fdv.uni-lj.si/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.adp.fdv.uni-lj.si/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+  ex:usesProperty vcard:url ;
+.
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.adp.fdv.uni-lj.si/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/harmonized/https://www.adp.fdv.uni-lj.si/ ;
   ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dct:conformsTo ;
-  ex:usesProperty dct:contactPoint ;
-  ex:usesProperty dct:publisher ;
-  ex:usesProperty dcat:service ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.adp.fdv.uni-lj.si/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.adp.fdv.uni-lj.si/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.adp.fdv.uni-lj.si/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.adp.fdv.uni-lj.si/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.adp.fdv.uni-lj.si/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
+ex:typeProfile_premis_PreservationPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.adp.fdv.uni-lj.si/ ;
+  ex:nodeType <premis:PreservationPolicy> ;
+  ex:usesProperty dct:title ;
 .
 
 eden://harvester/harmonized/https://www.bgee.org/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/harmonized/https://www.bgee.org/>"@en .
 
+ex:typeProfile_citation a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.bgee.org/ ;
+  ex:nodeType <http://localhost:3030/service_registry_store/citation> ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_CreativeWork a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.bgee.org/ ;
+  ex:nodeType <http://localhost:3030/service_registry_store/CreativeWork> ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_license a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.bgee.org/ ;
+  ex:nodeType <http://localhost:3030/service_registry_store/license> ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.bgee.org/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.bgee.org/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.bgee.org/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/harmonized/https://www.bgee.org/ ;
   ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dct:conformsTo ;
-  ex:usesProperty dct:contactPoint ;
-  ex:usesProperty dct:publisher ;
-  ex:usesProperty dcat:service ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.bgee.org/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.bgee.org/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.bgee.org/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.bgee.org/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.bgee.org/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
 .
 
 eden://harvester/harmonized/https://www.cathdb.info/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/harmonized/https://www.cathdb.info/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.cathdb.info/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.cathdb.info/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+  ex:usesProperty vcard:url ;
+.
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.cathdb.info/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/harmonized/https://www.cathdb.info/ ;
   ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dct:conformsTo ;
-  ex:usesProperty dct:contactPoint ;
-  ex:usesProperty dct:publisher ;
-  ex:usesProperty dcat:service ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.cathdb.info/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.cathdb.info/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.cathdb.info/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.cathdb.info/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.cathdb.info/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
 .
 
 eden://harvester/harmonized/https://www.cellosaurus.org/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/harmonized/https://www.cellosaurus.org/>"@en .
 
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.cellosaurus.org/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+  ex:usesProperty vcard:url ;
+.
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.cellosaurus.org/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/harmonized/https://www.cellosaurus.org/ ;
   ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dct:contactPoint ;
-  ex:usesProperty dct:publisher ;
-  ex:usesProperty dcat:service ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.cellosaurus.org/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.cellosaurus.org/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.cellosaurus.org/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.cellosaurus.org/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.cellosaurus.org/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
 .
 
 eden://harvester/harmonized/https://www.clarin.eu/content/national-consortia a ex:NamedGraph ;
   rdfs:label "<eden://harvester/harmonized/https://www.clarin.eu/content/national-consortia>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.clarin.eu/content/national-consortia ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.clarin.eu/content/national-consortia ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.clarin.eu/content/national-consortia ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/harmonized/https://www.clarin.eu/content/national-consortia ;
   ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dct:conformsTo ;
-  ex:usesProperty dct:contactPoint ;
-  ex:usesProperty dct:publisher ;
-  ex:usesProperty dcat:service ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.clarin.eu/content/national-consortia ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.clarin.eu/content/national-consortia ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.clarin.eu/content/national-consortia ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.clarin.eu/content/national-consortia ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.clarin.eu/content/national-consortia ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
 .
 
 eden://harvester/harmonized/https://www.crossda.hr/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/harmonized/https://www.crossda.hr/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.crossda.hr/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.crossda.hr/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.crossda.hr/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/harmonized/https://www.crossda.hr/ ;
   ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dct:conformsTo ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.crossda.hr/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.crossda.hr/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.crossda.hr/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.crossda.hr/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty foaf:name ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.crossda.hr/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
 .
 
 eden://harvester/harmonized/https://www.ebi.ac.uk/bioimage-archive/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/harmonized/https://www.ebi.ac.uk/bioimage-archive/>"@en .
 
+ex:typeProfile_ex_SustainabilityPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/bioimage-archive/ ;
+  ex:nodeType <ex:SustainabilityPolicy> ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/bioimage-archive/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/bioimage-archive/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+  ex:usesProperty vcard:url ;
+.
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/bioimage-archive/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/bioimage-archive/ ;
   ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dct:conformsTo ;
-  ex:usesProperty dct:contactPoint ;
-  ex:usesProperty dct:publisher ;
-  ex:usesProperty dcat:service ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/bioimage-archive/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/bioimage-archive/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/bioimage-archive/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/bioimage-archive/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/bioimage-archive/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
+ex:typeProfile_premis_PreservationPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/bioimage-archive/ ;
+  ex:nodeType <premis:PreservationPolicy> ;
+  ex:usesProperty dct:title ;
 .
 
 eden://harvester/harmonized/https://www.ebi.ac.uk/biosamples/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/harmonized/https://www.ebi.ac.uk/biosamples/>"@en .
 
+ex:typeProfile_ex_SustainabilityPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/biosamples/ ;
+  ex:nodeType <ex:SustainabilityPolicy> ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/biosamples/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/biosamples/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+  ex:usesProperty vcard:url ;
+.
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/biosamples/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/biosamples/ ;
   ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dct:conformsTo ;
-  ex:usesProperty dct:contactPoint ;
-  ex:usesProperty dct:publisher ;
-  ex:usesProperty dcat:service ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/biosamples/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/biosamples/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/biosamples/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/biosamples/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/biosamples/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
+ex:typeProfile_premis_PreservationPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/biosamples/ ;
+  ex:nodeType <premis:PreservationPolicy> ;
+  ex:usesProperty dct:title ;
 .
 
 eden://harvester/harmonized/https://www.ebi.ac.uk/biostudies/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/harmonized/https://www.ebi.ac.uk/biostudies/>"@en .
 
+ex:typeProfile_ex_SustainabilityPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/biostudies/ ;
+  ex:nodeType <ex:SustainabilityPolicy> ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/biostudies/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/biostudies/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+  ex:usesProperty vcard:url ;
+.
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/biostudies/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/biostudies/ ;
   ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dct:conformsTo ;
-  ex:usesProperty dct:contactPoint ;
-  ex:usesProperty dct:publisher ;
-  ex:usesProperty dcat:service ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/biostudies/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/biostudies/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/biostudies/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/biostudies/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/biostudies/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
+ex:typeProfile_premis_PreservationPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/biostudies/ ;
+  ex:nodeType <premis:PreservationPolicy> ;
+  ex:usesProperty dct:title ;
+.
+
+eden://harvester/harmonized/https://www.ebi.ac.uk/biostudies/arrayexpress a ex:NamedGraph ;
+  rdfs:label "<eden://harvester/harmonized/https://www.ebi.ac.uk/biostudies/arrayexpress>"@en .
+
+ex:typeProfile_ex_SustainabilityPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/biostudies/arrayexpress ;
+  ex:nodeType <ex:SustainabilityPolicy> ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/biostudies/arrayexpress ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/biostudies/arrayexpress ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+  ex:usesProperty vcard:url ;
+.
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/biostudies/arrayexpress ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
+ex:typeProfile_CatalogRecord a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/biostudies/arrayexpress ;
+  ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty prov:wasAssociatedWith ;
+  ex:usesProperty prov:wasGeneratedBy ;
+  ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/biostudies/arrayexpress ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/biostudies/arrayexpress ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/biostudies/arrayexpress ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/biostudies/arrayexpress ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/biostudies/arrayexpress ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
+ex:typeProfile_premis_PreservationPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/biostudies/arrayexpress ;
+  ex:nodeType <premis:PreservationPolicy> ;
+  ex:usesProperty dct:title ;
 .
 
 eden://harvester/harmonized/https://www.ebi.ac.uk/chembl/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/harmonized/https://www.ebi.ac.uk/chembl/>"@en .
 
+ex:typeProfile_ex_SustainabilityPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/chembl/ ;
+  ex:nodeType <ex:SustainabilityPolicy> ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/chembl/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/chembl/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+  ex:usesProperty vcard:url ;
+.
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/chembl/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/chembl/ ;
   ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dct:conformsTo ;
-  ex:usesProperty dct:contactPoint ;
-  ex:usesProperty dct:publisher ;
-  ex:usesProperty dcat:service ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/chembl/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/chembl/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/chembl/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/chembl/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/chembl/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
+ex:typeProfile_premis_PreservationPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/chembl/ ;
+  ex:nodeType <premis:PreservationPolicy> ;
+  ex:usesProperty dct:title ;
 .
 
 eden://harvester/harmonized/https://www.ebi.ac.uk/emdb/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/harmonized/https://www.ebi.ac.uk/emdb/>"@en .
 
+ex:typeProfile_ex_SustainabilityPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/emdb/ ;
+  ex:nodeType <ex:SustainabilityPolicy> ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/emdb/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/emdb/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+  ex:usesProperty vcard:url ;
+.
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/emdb/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/emdb/ ;
   ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dct:conformsTo ;
-  ex:usesProperty dct:contactPoint ;
-  ex:usesProperty dct:publisher ;
-  ex:usesProperty dcat:service ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/emdb/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/emdb/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/emdb/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/emdb/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/emdb/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
+ex:typeProfile_premis_PreservationPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/emdb/ ;
+  ex:nodeType <premis:PreservationPolicy> ;
+  ex:usesProperty dct:title ;
 .
 
 eden://harvester/harmonized/https://www.ebi.ac.uk/empiar/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/harmonized/https://www.ebi.ac.uk/empiar/>"@en .
 
+ex:typeProfile_ex_SustainabilityPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/empiar/ ;
+  ex:nodeType <ex:SustainabilityPolicy> ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/empiar/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/empiar/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+  ex:usesProperty vcard:url ;
+.
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/empiar/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/empiar/ ;
   ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dct:conformsTo ;
-  ex:usesProperty dct:contactPoint ;
-  ex:usesProperty dct:publisher ;
-  ex:usesProperty dcat:service ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/empiar/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/empiar/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/empiar/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/empiar/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/empiar/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
+ex:typeProfile_premis_PreservationPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/empiar/ ;
+  ex:nodeType <premis:PreservationPolicy> ;
+  ex:usesProperty dct:title ;
 .
 
 eden://harvester/harmonized/https://www.ebi.ac.uk/ena/browser/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/harmonized/https://www.ebi.ac.uk/ena/browser/>"@en .
 
+ex:typeProfile_ex_SustainabilityPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/ena/browser/ ;
+  ex:nodeType <ex:SustainabilityPolicy> ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/ena/browser/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/ena/browser/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+  ex:usesProperty vcard:url ;
+.
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/ena/browser/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/ena/browser/ ;
   ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dct:conformsTo ;
-  ex:usesProperty dct:contactPoint ;
-  ex:usesProperty dct:publisher ;
-  ex:usesProperty dcat:service ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/ena/browser/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/ena/browser/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/ena/browser/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/ena/browser/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/ena/browser/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
+ex:typeProfile_premis_PreservationPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/ena/browser/ ;
+  ex:nodeType <premis:PreservationPolicy> ;
+  ex:usesProperty dct:title ;
 .
 
 eden://harvester/harmonized/https://www.ebi.ac.uk/eva/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/harmonized/https://www.ebi.ac.uk/eva/>"@en .
 
+ex:typeProfile_ex_SustainabilityPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/eva/ ;
+  ex:nodeType <ex:SustainabilityPolicy> ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/eva/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/eva/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+  ex:usesProperty vcard:url ;
+.
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/eva/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/eva/ ;
   ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dct:conformsTo ;
-  ex:usesProperty dct:contactPoint ;
-  ex:usesProperty dct:publisher ;
-  ex:usesProperty dcat:service ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/eva/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/eva/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/eva/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/eva/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/eva/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
+ex:typeProfile_premis_PreservationPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/eva/ ;
+  ex:nodeType <premis:PreservationPolicy> ;
+  ex:usesProperty dct:title ;
 .
 
 eden://harvester/harmonized/https://www.ebi.ac.uk/gwas/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/harmonized/https://www.ebi.ac.uk/gwas/>"@en .
 
+ex:typeProfile_ex_SustainabilityPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/gwas/ ;
+  ex:nodeType <ex:SustainabilityPolicy> ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/gwas/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/gwas/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+  ex:usesProperty vcard:url ;
+.
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/gwas/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/gwas/ ;
   ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dct:conformsTo ;
-  ex:usesProperty dct:contactPoint ;
-  ex:usesProperty dct:publisher ;
-  ex:usesProperty dcat:service ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/gwas/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/gwas/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/gwas/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/gwas/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/gwas/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
+ex:typeProfile_premis_PreservationPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/gwas/ ;
+  ex:nodeType <premis:PreservationPolicy> ;
+  ex:usesProperty dct:title ;
 .
 
 eden://harvester/harmonized/https://www.ebi.ac.uk/intact/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/harmonized/https://www.ebi.ac.uk/intact/>"@en .
 
+ex:typeProfile_ex_SustainabilityPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/intact/ ;
+  ex:nodeType <ex:SustainabilityPolicy> ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/intact/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/intact/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+  ex:usesProperty vcard:url ;
+.
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/intact/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/intact/ ;
   ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dct:conformsTo ;
-  ex:usesProperty dct:contactPoint ;
-  ex:usesProperty dct:publisher ;
-  ex:usesProperty dcat:service ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/intact/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/intact/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/intact/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/intact/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/intact/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
+ex:typeProfile_premis_PreservationPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/intact/ ;
+  ex:nodeType <premis:PreservationPolicy> ;
+  ex:usesProperty dct:title ;
 .
 
 eden://harvester/harmonized/https://www.ebi.ac.uk/metabolights/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/harmonized/https://www.ebi.ac.uk/metabolights/>"@en .
 
+ex:typeProfile_ex_SustainabilityPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/metabolights/ ;
+  ex:nodeType <ex:SustainabilityPolicy> ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/metabolights/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/metabolights/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+  ex:usesProperty vcard:url ;
+.
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/metabolights/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/metabolights/ ;
   ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dct:conformsTo ;
-  ex:usesProperty dct:contactPoint ;
-  ex:usesProperty dct:publisher ;
-  ex:usesProperty dcat:service ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/metabolights/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/metabolights/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/metabolights/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/metabolights/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/metabolights/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
+ex:typeProfile_premis_PreservationPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/metabolights/ ;
+  ex:nodeType <premis:PreservationPolicy> ;
+  ex:usesProperty dct:title ;
 .
 
 eden://harvester/harmonized/https://www.ebi.ac.uk/pdbe/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/harmonized/https://www.ebi.ac.uk/pdbe/>"@en .
 
+ex:typeProfile_ex_SustainabilityPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/pdbe/ ;
+  ex:nodeType <ex:SustainabilityPolicy> ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/pdbe/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/pdbe/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+  ex:usesProperty vcard:url ;
+.
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/pdbe/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/pdbe/ ;
   ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dct:conformsTo ;
-  ex:usesProperty dct:contactPoint ;
-  ex:usesProperty dct:publisher ;
-  ex:usesProperty dcat:service ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/pdbe/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/pdbe/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/pdbe/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/pdbe/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/pdbe/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
+ex:typeProfile_premis_PreservationPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/pdbe/ ;
+  ex:nodeType <premis:PreservationPolicy> ;
+  ex:usesProperty dct:title ;
 .
 
 eden://harvester/harmonized/https://www.ebi.ac.uk/pride/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/harmonized/https://www.ebi.ac.uk/pride/>"@en .
 
+ex:typeProfile_ex_SustainabilityPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/pride/ ;
+  ex:nodeType <ex:SustainabilityPolicy> ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/pride/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/pride/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+  ex:usesProperty vcard:url ;
+.
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/pride/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/pride/ ;
   ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dct:conformsTo ;
-  ex:usesProperty dct:contactPoint ;
-  ex:usesProperty dct:publisher ;
-  ex:usesProperty dcat:service ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/pride/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/pride/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/pride/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/pride/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/pride/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
+ex:typeProfile_premis_PreservationPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ebi.ac.uk/pride/ ;
+  ex:nodeType <premis:PreservationPolicy> ;
+  ex:usesProperty dct:title ;
 .
 
 eden://harvester/harmonized/https://www.fairdata.fi/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/harmonized/https://www.fairdata.fi/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.fairdata.fi/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.fairdata.fi/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.fairdata.fi/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:language ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/harmonized/https://www.fairdata.fi/ ;
   ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dct:conformsTo ;
-  ex:usesProperty dct:contactPoint ;
-  ex:usesProperty dct:publisher ;
-  ex:usesProperty dcat:service ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.fairdata.fi/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.fairdata.fi/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.fairdata.fi/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.fairdata.fi/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.fairdata.fi/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:language ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
 .
 
 eden://harvester/harmonized/https://www.fsd.tuni.fi/en/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/harmonized/https://www.fsd.tuni.fi/en/>"@en .
 
+ex:typeProfile_ex_SustainabilityPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.fsd.tuni.fi/en/ ;
+  ex:nodeType <ex:SustainabilityPolicy> ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.fsd.tuni.fi/en/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.fsd.tuni.fi/en/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.fsd.tuni.fi/en/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/harmonized/https://www.fsd.tuni.fi/en/ ;
   ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dct:conformsTo ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.fsd.tuni.fi/en/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.fsd.tuni.fi/en/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.fsd.tuni.fi/en/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.fsd.tuni.fi/en/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.fsd.tuni.fi/en/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
+ex:typeProfile_premis_PreservationPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.fsd.tuni.fi/en/ ;
+  ex:nodeType <premis:PreservationPolicy> ;
+  ex:usesProperty dct:title ;
 .
 
 eden://harvester/harmonized/https://www.kielipankki.fi/language-bank/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/harmonized/https://www.kielipankki.fi/language-bank/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.kielipankki.fi/language-bank/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.kielipankki.fi/language-bank/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+  ex:usesProperty vcard:url ;
+.
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.kielipankki.fi/language-bank/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/harmonized/https://www.kielipankki.fi/language-bank/ ;
   ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dct:conformsTo ;
-  ex:usesProperty dct:contactPoint ;
-  ex:usesProperty dct:publisher ;
-  ex:usesProperty dcat:service ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.kielipankki.fi/language-bank/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.kielipankki.fi/language-bank/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.kielipankki.fi/language-bank/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.kielipankki.fi/language-bank/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.kielipankki.fi/language-bank/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
 .
 
 eden://harvester/harmonized/https://www.ldc.upenn.edu/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/harmonized/https://www.ldc.upenn.edu/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ldc.upenn.edu/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ldc.upenn.edu/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+  ex:usesProperty vcard:url ;
+.
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ldc.upenn.edu/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/harmonized/https://www.ldc.upenn.edu/ ;
   ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dct:conformsTo ;
-  ex:usesProperty dct:contactPoint ;
-  ex:usesProperty dct:publisher ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ldc.upenn.edu/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ldc.upenn.edu/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ldc.upenn.edu/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ldc.upenn.edu/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty prov:hadPrimarySource ;
 .
 
 eden://harvester/harmonized/https://www.lipidmaps.org/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/harmonized/https://www.lipidmaps.org/>"@en .
 
+ex:typeProfile_ex_SustainabilityPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.lipidmaps.org/ ;
+  ex:nodeType <ex:SustainabilityPolicy> ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.lipidmaps.org/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.lipidmaps.org/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:url ;
+.
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.lipidmaps.org/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/harmonized/https://www.lipidmaps.org/ ;
   ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dct:conformsTo ;
-  ex:usesProperty dct:contactPoint ;
-  ex:usesProperty dct:publisher ;
-  ex:usesProperty dcat:service ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.lipidmaps.org/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.lipidmaps.org/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.lipidmaps.org/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.lipidmaps.org/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.lipidmaps.org/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
+ex:typeProfile_premis_PreservationPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.lipidmaps.org/ ;
+  ex:nodeType <premis:PreservationPolicy> ;
+  ex:usesProperty dct:title ;
 .
 
 eden://harvester/harmonized/https://www.orthodb.org/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/harmonized/https://www.orthodb.org/>"@en .
 
+ex:typeProfile_CreativeWork a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.orthodb.org/ ;
+  ex:nodeType <http://localhost:3030/service_registry_store/CreativeWork> ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_license a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.orthodb.org/ ;
+  ex:nodeType <http://localhost:3030/service_registry_store/license> ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.orthodb.org/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.orthodb.org/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.orthodb.org/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/harmonized/https://www.orthodb.org/ ;
   ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dct:conformsTo ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.orthodb.org/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.orthodb.org/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.orthodb.org/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.orthodb.org/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.orthodb.org/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
 .
 
 eden://harvester/harmonized/https://www.ortolang.fr/en/home/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/harmonized/https://www.ortolang.fr/en/home/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ortolang.fr/en/home/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ortolang.fr/en/home/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+  ex:usesProperty vcard:url ;
+.
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ortolang.fr/en/home/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/harmonized/https://www.ortolang.fr/en/home/ ;
   ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dct:conformsTo ;
-  ex:usesProperty dct:contactPoint ;
-  ex:usesProperty dct:publisher ;
-  ex:usesProperty dcat:service ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ortolang.fr/en/home/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ortolang.fr/en/home/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ortolang.fr/en/home/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ortolang.fr/en/home/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.ortolang.fr/en/home/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
 .
 
 eden://harvester/harmonized/https://www.paradisec.org.au/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/harmonized/https://www.paradisec.org.au/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.paradisec.org.au/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.paradisec.org.au/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+  ex:usesProperty vcard:url ;
+.
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.paradisec.org.au/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/harmonized/https://www.paradisec.org.au/ ;
   ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dct:conformsTo ;
-  ex:usesProperty dct:contactPoint ;
-  ex:usesProperty dct:publisher ;
-  ex:usesProperty dcat:service ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.paradisec.org.au/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.paradisec.org.au/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.paradisec.org.au/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.paradisec.org.au/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.paradisec.org.au/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
 .
 
 eden://harvester/harmonized/https://www.progedo.fr/en/home/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/harmonized/https://www.progedo.fr/en/home/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.progedo.fr/en/home/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.progedo.fr/en/home/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+  ex:usesProperty vcard:url ;
+.
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.progedo.fr/en/home/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/harmonized/https://www.progedo.fr/en/home/ ;
   ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dct:conformsTo ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.progedo.fr/en/home/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.progedo.fr/en/home/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.progedo.fr/en/home/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.progedo.fr/en/home/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.progedo.fr/en/home/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
 .
 
 eden://harvester/harmonized/https://www.rohub.org/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/harmonized/https://www.rohub.org/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.rohub.org/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.rohub.org/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.rohub.org/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/harmonized/https://www.rohub.org/ ;
   ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dct:conformsTo ;
-  ex:usesProperty dct:contactPoint ;
-  ex:usesProperty dct:publisher ;
-  ex:usesProperty dcat:service ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.rohub.org/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.rohub.org/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.rohub.org/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.rohub.org/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.rohub.org/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
 .
 
 eden://harvester/harmonized/https://www.sodha.be/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/harmonized/https://www.sodha.be/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.sodha.be/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.sodha.be/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.sodha.be/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/harmonized/https://www.sodha.be/ ;
   ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dct:conformsTo ;
-  ex:usesProperty dct:contactPoint ;
-  ex:usesProperty dct:publisher ;
-  ex:usesProperty dcat:service ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.sodha.be/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.sodha.be/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.sodha.be/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.sodha.be/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.sodha.be/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
 .
 
 eden://harvester/harmonized/https://www.storedb.org/store_v3/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/harmonized/https://www.storedb.org/store_v3/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.storedb.org/store_v3/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.storedb.org/store_v3/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+  ex:usesProperty vcard:url ;
+.
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.storedb.org/store_v3/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/harmonized/https://www.storedb.org/store_v3/ ;
   ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dct:conformsTo ;
-  ex:usesProperty dct:contactPoint ;
-  ex:usesProperty dct:publisher ;
-  ex:usesProperty dcat:service ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.storedb.org/store_v3/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.storedb.org/store_v3/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.storedb.org/store_v3/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.storedb.org/store_v3/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.storedb.org/store_v3/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
 .
 
 eden://harvester/harmonized/https://www.tarki.hu/eng a ex:NamedGraph ;
   rdfs:label "<eden://harvester/harmonized/https://www.tarki.hu/eng>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.tarki.hu/eng ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.tarki.hu/eng ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.tarki.hu/eng ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/harmonized/https://www.tarki.hu/eng ;
   ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dct:conformsTo ;
-  ex:usesProperty dct:contactPoint ;
-  ex:usesProperty dct:publisher ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.tarki.hu/eng ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.tarki.hu/eng ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.tarki.hu/eng ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.tarki.hu/eng ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty prov:hadPrimarySource ;
 .
 
 eden://harvester/harmonized/https://www.uniprot.org/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/harmonized/https://www.uniprot.org/>"@en .
 
+ex:typeProfile_ex_SustainabilityPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.uniprot.org/ ;
+  ex:nodeType <ex:SustainabilityPolicy> ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.uniprot.org/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.uniprot.org/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:url ;
+.
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.uniprot.org/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/harmonized/https://www.uniprot.org/ ;
   ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dct:conformsTo ;
-  ex:usesProperty dct:contactPoint ;
-  ex:usesProperty dct:publisher ;
-  ex:usesProperty dcat:service ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
 .
 
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.uniprot.org/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.uniprot.org/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.uniprot.org/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.uniprot.org/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.uniprot.org/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
+ex:typeProfile_premis_PreservationPolicy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.uniprot.org/ ;
+  ex:nodeType <premis:PreservationPolicy> ;
+  ex:usesProperty dct:title ;
+.
+
 eden://harvester/harmonized/https://www.wdc-climate.de/ui/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/harmonized/https://www.wdc-climate.de/ui/>"@en .
+
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.wdc-climate.de/ui/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.wdc-climate.de/ui/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.wdc-climate.de/ui/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:language ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/harmonized/https://www.wdc-climate.de/ui/ ;
   ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dct:conformsTo ;
-  ex:usesProperty dct:contactPoint ;
-  ex:usesProperty dct:publisher ;
-  ex:usesProperty dcat:service ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.wdc-climate.de/ui/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.wdc-climate.de/ui/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.wdc-climate.de/ui/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.wdc-climate.de/ui/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/harmonized/https://www.wdc-climate.de/ui/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:language ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
 .
 
 eden://harvester/linked_jsonld/https://anc.plus.ac.at/index.html a ex:NamedGraph ;
@@ -3716,16 +13821,51 @@ ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:language ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/linked_jsonld/https://anc.plus.ac.at/index.html ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/linked_jsonld/https://anc.plus.ac.at/index.html ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/linked_jsonld/https://anc.plus.ac.at/index.html ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/linked_jsonld/https://anc.plus.ac.at/index.html ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/linked_jsonld/https://anc.plus.ac.at/index.html ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -3733,512 +13873,1889 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:language ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 eden://harvester/meta_tags/https://about.coscine.de/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/meta_tags/https://about.coscine.de/>"@en .
 
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://about.coscine.de/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/meta_tags/https://about.coscine.de/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://about.coscine.de/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://about.coscine.de/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://about.coscine.de/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
 .
 
 eden://harvester/meta_tags/https://archiv.soc.cas.cz/en/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/meta_tags/https://archiv.soc.cas.cz/en/>"@en .
 
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://archiv.soc.cas.cz/en/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/meta_tags/https://archiv.soc.cas.cz/en/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://archiv.soc.cas.cz/en/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://archiv.soc.cas.cz/en/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://archiv.soc.cas.cz/en/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
 .
 
 eden://harvester/meta_tags/https://aussda.at/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/meta_tags/https://aussda.at/>"@en .
 
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://aussda.at/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/meta_tags/https://aussda.at/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://aussda.at/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://aussda.at/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://aussda.at/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
 .
 
 eden://harvester/meta_tags/https://bacdive.dsmz.de/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/meta_tags/https://bacdive.dsmz.de/>"@en .
 
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://bacdive.dsmz.de/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/meta_tags/https://bacdive.dsmz.de/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://bacdive.dsmz.de/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://bacdive.dsmz.de/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://bacdive.dsmz.de/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
 .
 
 eden://harvester/meta_tags/https://biomodels.org/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/meta_tags/https://biomodels.org/>"@en .
 
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://biomodels.org/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/meta_tags/https://biomodels.org/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://biomodels.org/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://biomodels.org/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://biomodels.org/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
 .
 
 eden://harvester/meta_tags/https://borealisdata.ca/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/meta_tags/https://borealisdata.ca/>"@en .
 
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://borealisdata.ca/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/meta_tags/https://borealisdata.ca/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://borealisdata.ca/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://borealisdata.ca/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://borealisdata.ca/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
 .
 
 eden://harvester/meta_tags/https://dans.knaw.nl/nl/life-sciences/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/meta_tags/https://dans.knaw.nl/nl/life-sciences/>"@en .
 
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://dans.knaw.nl/nl/life-sciences/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/meta_tags/https://dans.knaw.nl/nl/life-sciences/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://dans.knaw.nl/nl/life-sciences/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://dans.knaw.nl/nl/life-sciences/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://dans.knaw.nl/nl/life-sciences/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
 .
 
 eden://harvester/meta_tags/https://dans.knaw.nl/nl/social-sciences-and-humanities/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/meta_tags/https://dans.knaw.nl/nl/social-sciences-and-humanities/>"@en .
 
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://dans.knaw.nl/nl/social-sciences-and-humanities/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/meta_tags/https://dans.knaw.nl/nl/social-sciences-and-humanities/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://dans.knaw.nl/nl/social-sciences-and-humanities/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://dans.knaw.nl/nl/social-sciences-and-humanities/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://dans.knaw.nl/nl/social-sciences-and-humanities/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
 .
 
 eden://harvester/meta_tags/https://data.4tu.nl/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/meta_tags/https://data.4tu.nl/>"@en .
 
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://data.4tu.nl/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/meta_tags/https://data.4tu.nl/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://data.4tu.nl/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://data.4tu.nl/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://data.4tu.nl/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
 .
 
 eden://harvester/meta_tags/https://datarepositorium.uminho.pt/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/meta_tags/https://datarepositorium.uminho.pt/>"@en .
 
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://datarepositorium.uminho.pt/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/meta_tags/https://datarepositorium.uminho.pt/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://datarepositorium.uminho.pt/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://datarepositorium.uminho.pt/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://datarepositorium.uminho.pt/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
 .
 
 eden://harvester/meta_tags/https://dataverse.no/dataverse/trolling a ex:NamedGraph ;
   rdfs:label "<eden://harvester/meta_tags/https://dataverse.no/dataverse/trolling>"@en .
 
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://dataverse.no/dataverse/trolling ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/meta_tags/https://dataverse.no/dataverse/trolling ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://dataverse.no/dataverse/trolling ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://dataverse.no/dataverse/trolling ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://dataverse.no/dataverse/trolling ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
 .
 
 eden://harvester/meta_tags/https://ega-archive.org/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/meta_tags/https://ega-archive.org/>"@en .
 
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://ega-archive.org/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/meta_tags/https://ega-archive.org/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://ega-archive.org/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://ega-archive.org/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://ega-archive.org/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
 .
 
 eden://harvester/meta_tags/https://glittr.org/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/meta_tags/https://glittr.org/>"@en .
 
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://glittr.org/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/meta_tags/https://glittr.org/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://glittr.org/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://glittr.org/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://glittr.org/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
 .
 
 eden://harvester/meta_tags/https://gude.uni-frankfurt.de/home a ex:NamedGraph ;
   rdfs:label "<eden://harvester/meta_tags/https://gude.uni-frankfurt.de/home>"@en .
 
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://gude.uni-frankfurt.de/home ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/meta_tags/https://gude.uni-frankfurt.de/home ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://gude.uni-frankfurt.de/home ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://gude.uni-frankfurt.de/home ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://gude.uni-frankfurt.de/home ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
 .
 
 eden://harvester/meta_tags/https://library.camtree.org/home a ex:NamedGraph ;
   rdfs:label "<eden://harvester/meta_tags/https://library.camtree.org/home>"@en .
 
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://library.camtree.org/home ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/meta_tags/https://library.camtree.org/home ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://library.camtree.org/home ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://library.camtree.org/home ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://library.camtree.org/home ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
 .
 
 eden://harvester/meta_tags/https://lida.dataverse.lt/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/meta_tags/https://lida.dataverse.lt/>"@en .
 
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://lida.dataverse.lt/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/meta_tags/https://lida.dataverse.lt/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://lida.dataverse.lt/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://lida.dataverse.lt/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://lida.dataverse.lt/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
 .
 
 eden://harvester/meta_tags/https://modelarchive.org/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/meta_tags/https://modelarchive.org/>"@en .
 
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://modelarchive.org/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/meta_tags/https://modelarchive.org/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://modelarchive.org/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://modelarchive.org/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://modelarchive.org/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
 .
 
 eden://harvester/meta_tags/https://omabrowser.org/oma/home/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/meta_tags/https://omabrowser.org/oma/home/>"@en .
 
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://omabrowser.org/oma/home/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/meta_tags/https://omabrowser.org/oma/home/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://omabrowser.org/oma/home/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://omabrowser.org/oma/home/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://omabrowser.org/oma/home/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
 .
 
 eden://harvester/meta_tags/https://reactome.org/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/meta_tags/https://reactome.org/>"@en .
 
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://reactome.org/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/meta_tags/https://reactome.org/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://reactome.org/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://reactome.org/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://reactome.org/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
 .
 
 eden://harvester/meta_tags/https://recherche.data.gouv.fr/en/page/about-recherche-data-gouv a ex:NamedGraph ;
   rdfs:label "<eden://harvester/meta_tags/https://recherche.data.gouv.fr/en/page/about-recherche-data-gouv>"@en .
 
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://recherche.data.gouv.fr/en/page/about-recherche-data-gouv ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/meta_tags/https://recherche.data.gouv.fr/en/page/about-recherche-data-gouv ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://recherche.data.gouv.fr/en/page/about-recherche-data-gouv ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://recherche.data.gouv.fr/en/page/about-recherche-data-gouv ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://recherche.data.gouv.fr/en/page/about-recherche-data-gouv ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
 .
 
 eden://harvester/meta_tags/https://repo.researchdata.hu/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/meta_tags/https://repo.researchdata.hu/>"@en .
 
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://repo.researchdata.hu/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/meta_tags/https://repo.researchdata.hu/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://repo.researchdata.hu/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://repo.researchdata.hu/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://repo.researchdata.hu/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
 .
 
 eden://harvester/meta_tags/https://sikt.no/en/archiving-research-data a ex:NamedGraph ;
   rdfs:label "<eden://harvester/meta_tags/https://sikt.no/en/archiving-research-data>"@en .
 
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://sikt.no/en/archiving-research-data ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/meta_tags/https://sikt.no/en/archiving-research-data ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://sikt.no/en/archiving-research-data ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://sikt.no/en/archiving-research-data ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://sikt.no/en/archiving-research-data ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
 .
 
 eden://harvester/meta_tags/https://site.uit.no/dataverseno/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/meta_tags/https://site.uit.no/dataverseno/>"@en .
 
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://site.uit.no/dataverseno/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/meta_tags/https://site.uit.no/dataverseno/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://site.uit.no/dataverseno/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://site.uit.no/dataverseno/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://site.uit.no/dataverseno/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
 .
 
 eden://harvester/meta_tags/https://ukdataservice.ac.uk/about/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/meta_tags/https://ukdataservice.ac.uk/about/>"@en .
 
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://ukdataservice.ac.uk/about/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/meta_tags/https://ukdataservice.ac.uk/about/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://ukdataservice.ac.uk/about/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://ukdataservice.ac.uk/about/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://ukdataservice.ac.uk/about/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
 .
 
 eden://harvester/meta_tags/https://www.bgee.org/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/meta_tags/https://www.bgee.org/>"@en .
 
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://www.bgee.org/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/meta_tags/https://www.bgee.org/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://www.bgee.org/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://www.bgee.org/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://www.bgee.org/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
 .
 
 eden://harvester/meta_tags/https://www.cellosaurus.org/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/meta_tags/https://www.cellosaurus.org/>"@en .
 
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://www.cellosaurus.org/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/meta_tags/https://www.cellosaurus.org/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://www.cellosaurus.org/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://www.cellosaurus.org/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://www.cellosaurus.org/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
 .
 
 eden://harvester/meta_tags/https://www.clarin.eu/content/national-consortia a ex:NamedGraph ;
   rdfs:label "<eden://harvester/meta_tags/https://www.clarin.eu/content/national-consortia>"@en .
 
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://www.clarin.eu/content/national-consortia ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/meta_tags/https://www.clarin.eu/content/national-consortia ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://www.clarin.eu/content/national-consortia ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://www.clarin.eu/content/national-consortia ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://www.clarin.eu/content/national-consortia ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
 .
 
 eden://harvester/meta_tags/https://www.ebi.ac.uk/bioimage-archive/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/meta_tags/https://www.ebi.ac.uk/bioimage-archive/>"@en .
 
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://www.ebi.ac.uk/bioimage-archive/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/meta_tags/https://www.ebi.ac.uk/bioimage-archive/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://www.ebi.ac.uk/bioimage-archive/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://www.ebi.ac.uk/bioimage-archive/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://www.ebi.ac.uk/bioimage-archive/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
 .
 
 eden://harvester/meta_tags/https://www.ebi.ac.uk/biostudies/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/meta_tags/https://www.ebi.ac.uk/biostudies/>"@en .
 
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://www.ebi.ac.uk/biostudies/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/meta_tags/https://www.ebi.ac.uk/biostudies/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://www.ebi.ac.uk/biostudies/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://www.ebi.ac.uk/biostudies/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://www.ebi.ac.uk/biostudies/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
 .
 
 eden://harvester/meta_tags/https://www.ebi.ac.uk/biostudies/arrayexpress a ex:NamedGraph ;
   rdfs:label "<eden://harvester/meta_tags/https://www.ebi.ac.uk/biostudies/arrayexpress>"@en .
 
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://www.ebi.ac.uk/biostudies/arrayexpress ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/meta_tags/https://www.ebi.ac.uk/biostudies/arrayexpress ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://www.ebi.ac.uk/biostudies/arrayexpress ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://www.ebi.ac.uk/biostudies/arrayexpress ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://www.ebi.ac.uk/biostudies/arrayexpress ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
 .
 
 eden://harvester/meta_tags/https://www.ebi.ac.uk/emdb/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/meta_tags/https://www.ebi.ac.uk/emdb/>"@en .
 
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://www.ebi.ac.uk/emdb/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/meta_tags/https://www.ebi.ac.uk/emdb/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://www.ebi.ac.uk/emdb/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://www.ebi.ac.uk/emdb/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://www.ebi.ac.uk/emdb/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
 .
 
 eden://harvester/meta_tags/https://www.ebi.ac.uk/empiar/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/meta_tags/https://www.ebi.ac.uk/empiar/>"@en .
 
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://www.ebi.ac.uk/empiar/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/meta_tags/https://www.ebi.ac.uk/empiar/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://www.ebi.ac.uk/empiar/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://www.ebi.ac.uk/empiar/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://www.ebi.ac.uk/empiar/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
 .
 
 eden://harvester/meta_tags/https://www.ebi.ac.uk/ena/browser/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/meta_tags/https://www.ebi.ac.uk/ena/browser/>"@en .
 
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://www.ebi.ac.uk/ena/browser/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/meta_tags/https://www.ebi.ac.uk/ena/browser/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://www.ebi.ac.uk/ena/browser/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://www.ebi.ac.uk/ena/browser/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://www.ebi.ac.uk/ena/browser/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
 .
 
 eden://harvester/meta_tags/https://www.ebi.ac.uk/eva/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/meta_tags/https://www.ebi.ac.uk/eva/>"@en .
 
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://www.ebi.ac.uk/eva/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/meta_tags/https://www.ebi.ac.uk/eva/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://www.ebi.ac.uk/eva/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://www.ebi.ac.uk/eva/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://www.ebi.ac.uk/eva/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
 .
 
 eden://harvester/meta_tags/https://www.ebi.ac.uk/gwas/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/meta_tags/https://www.ebi.ac.uk/gwas/>"@en .
 
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://www.ebi.ac.uk/gwas/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/meta_tags/https://www.ebi.ac.uk/gwas/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://www.ebi.ac.uk/gwas/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://www.ebi.ac.uk/gwas/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://www.ebi.ac.uk/gwas/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
 .
 
 eden://harvester/meta_tags/https://www.ebi.ac.uk/intact/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/meta_tags/https://www.ebi.ac.uk/intact/>"@en .
 
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://www.ebi.ac.uk/intact/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/meta_tags/https://www.ebi.ac.uk/intact/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://www.ebi.ac.uk/intact/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://www.ebi.ac.uk/intact/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://www.ebi.ac.uk/intact/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
 .
 
 eden://harvester/meta_tags/https://www.ebi.ac.uk/metabolights/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/meta_tags/https://www.ebi.ac.uk/metabolights/>"@en .
 
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://www.ebi.ac.uk/metabolights/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/meta_tags/https://www.ebi.ac.uk/metabolights/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://www.ebi.ac.uk/metabolights/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://www.ebi.ac.uk/metabolights/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://www.ebi.ac.uk/metabolights/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
 .
 
 eden://harvester/meta_tags/https://www.ebi.ac.uk/pride/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/meta_tags/https://www.ebi.ac.uk/pride/>"@en .
 
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://www.ebi.ac.uk/pride/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/meta_tags/https://www.ebi.ac.uk/pride/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://www.ebi.ac.uk/pride/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://www.ebi.ac.uk/pride/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://www.ebi.ac.uk/pride/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
 .
 
 eden://harvester/meta_tags/https://www.fairdata.fi/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/meta_tags/https://www.fairdata.fi/>"@en .
 
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://www.fairdata.fi/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/meta_tags/https://www.fairdata.fi/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://www.fairdata.fi/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://www.fairdata.fi/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://www.fairdata.fi/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
 .
 
 eden://harvester/meta_tags/https://www.fsd.tuni.fi/en/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/meta_tags/https://www.fsd.tuni.fi/en/>"@en .
 
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://www.fsd.tuni.fi/en/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/meta_tags/https://www.fsd.tuni.fi/en/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://www.fsd.tuni.fi/en/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://www.fsd.tuni.fi/en/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://www.fsd.tuni.fi/en/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
 .
 
 eden://harvester/meta_tags/https://www.lipidmaps.org/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/meta_tags/https://www.lipidmaps.org/>"@en .
 
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://www.lipidmaps.org/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/meta_tags/https://www.lipidmaps.org/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://www.lipidmaps.org/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://www.lipidmaps.org/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://www.lipidmaps.org/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
 .
 
 eden://harvester/meta_tags/https://www.ortolang.fr/en/home/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/meta_tags/https://www.ortolang.fr/en/home/>"@en .
 
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://www.ortolang.fr/en/home/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/meta_tags/https://www.ortolang.fr/en/home/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://www.ortolang.fr/en/home/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://www.ortolang.fr/en/home/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://www.ortolang.fr/en/home/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
 .
 
 eden://harvester/meta_tags/https://www.progedo.fr/en/home/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/meta_tags/https://www.progedo.fr/en/home/>"@en .
 
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://www.progedo.fr/en/home/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/meta_tags/https://www.progedo.fr/en/home/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://www.progedo.fr/en/home/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://www.progedo.fr/en/home/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://www.progedo.fr/en/home/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
 .
 
 eden://harvester/meta_tags/https://www.sodha.be/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/meta_tags/https://www.sodha.be/>"@en .
 
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://www.sodha.be/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
+.
+
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/meta_tags/https://www.sodha.be/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
 .
 
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://www.sodha.be/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://www.sodha.be/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/meta_tags/https://www.sodha.be/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:type ;
+.
+
 eden://harvester/re3data/https://about.coscine.de/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/re3data/https://about.coscine.de/>"@en .
+
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://about.coscine.de/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://about.coscine.de/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
 
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://about.coscine.de/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://about.coscine.de/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://about.coscine.de/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://about.coscine.de/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://about.coscine.de/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://about.coscine.de/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -4246,50 +15763,157 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 eden://harvester/re3data/https://agroportal.eu/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/re3data/https://agroportal.eu/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://agroportal.eu/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://agroportal.eu/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+  ex:usesProperty vcard:url ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://agroportal.eu/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://agroportal.eu/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://agroportal.eu/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://agroportal.eu/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://agroportal.eu/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://agroportal.eu/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://agroportal.eu/ ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
 .
 
 eden://harvester/re3data/https://anc.plus.ac.at/index.html a ex:NamedGraph ;
   rdfs:label "<eden://harvester/re3data/https://anc.plus.ac.at/index.html>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://anc.plus.ac.at/index.html ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://anc.plus.ac.at/index.html ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://anc.plus.ac.at/index.html ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://anc.plus.ac.at/index.html ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://anc.plus.ac.at/index.html ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://anc.plus.ac.at/index.html ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://anc.plus.ac.at/index.html ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -4297,27 +15921,81 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 eden://harvester/re3data/https://archiv.soc.cas.cz/en/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/re3data/https://archiv.soc.cas.cz/en/>"@en .
+
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://archiv.soc.cas.cz/en/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://archiv.soc.cas.cz/en/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
 
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://archiv.soc.cas.cz/en/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://archiv.soc.cas.cz/en/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://archiv.soc.cas.cz/en/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://archiv.soc.cas.cz/en/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://archiv.soc.cas.cz/en/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://archiv.soc.cas.cz/en/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -4325,28 +16003,82 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 eden://harvester/re3data/https://aussda.at/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/re3data/https://aussda.at/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://aussda.at/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://aussda.at/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://aussda.at/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://aussda.at/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://aussda.at/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://aussda.at/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://aussda.at/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://aussda.at/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -4354,28 +16086,83 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 eden://harvester/re3data/https://bacdive.dsmz.de/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/re3data/https://bacdive.dsmz.de/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://bacdive.dsmz.de/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://bacdive.dsmz.de/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+  ex:usesProperty vcard:url ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://bacdive.dsmz.de/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://bacdive.dsmz.de/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://bacdive.dsmz.de/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://bacdive.dsmz.de/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://bacdive.dsmz.de/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://bacdive.dsmz.de/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -4383,27 +16170,82 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 eden://harvester/re3data/https://borealisdata.ca/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/re3data/https://borealisdata.ca/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://borealisdata.ca/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://borealisdata.ca/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:url ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://borealisdata.ca/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
-  ex:usesProperty vcard:url ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://borealisdata.ca/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://borealisdata.ca/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://borealisdata.ca/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://borealisdata.ca/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://borealisdata.ca/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -4411,27 +16253,82 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
-  ex:usesProperty vcard:url ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
 .
 
 eden://harvester/re3data/https://cds.unistra.fr/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/re3data/https://cds.unistra.fr/>"@en .
+
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://cds.unistra.fr/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://cds.unistra.fr/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
 
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://cds.unistra.fr/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://cds.unistra.fr/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://cds.unistra.fr/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://cds.unistra.fr/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://cds.unistra.fr/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://cds.unistra.fr/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -4439,27 +16336,73 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 eden://harvester/re3data/https://cer.ihtm.bg.ac.rs/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/re3data/https://cer.ihtm.bg.ac.rs/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://cer.ihtm.bg.ac.rs/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://cer.ihtm.bg.ac.rs/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://cer.ihtm.bg.ac.rs/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://cer.ihtm.bg.ac.rs/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://cer.ihtm.bg.ac.rs/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://cer.ihtm.bg.ac.rs/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://cer.ihtm.bg.ac.rs/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -4467,54 +16410,238 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 eden://harvester/re3data/https://dais.sanu.ac.rs/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/re3data/https://dais.sanu.ac.rs/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://dais.sanu.ac.rs/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://dais.sanu.ac.rs/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+  ex:usesProperty vcard:url ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://dais.sanu.ac.rs/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://dais.sanu.ac.rs/ ;
   ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dct:conformsTo ;
-  ex:usesProperty dct:contactPoint ;
-  ex:usesProperty dct:publisher ;
-  ex:usesProperty dcat:service ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://dais.sanu.ac.rs/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://dais.sanu.ac.rs/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://dais.sanu.ac.rs/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://dais.sanu.ac.rs/ ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+.
+
+eden://harvester/re3data/https://dans.knaw.nl/nl/life-sciences/ a ex:NamedGraph ;
+  rdfs:label "<eden://harvester/re3data/https://dans.knaw.nl/nl/life-sciences/>"@en .
+
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://dans.knaw.nl/nl/life-sciences/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://dans.knaw.nl/nl/life-sciences/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://dans.knaw.nl/nl/life-sciences/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+.
+
+ex:typeProfile_CatalogRecord a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://dans.knaw.nl/nl/life-sciences/ ;
+  ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
+  ex:usesProperty prov:wasAssociatedWith ;
+  ex:usesProperty prov:wasGeneratedBy ;
+  ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://dans.knaw.nl/nl/life-sciences/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://dans.knaw.nl/nl/life-sciences/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://dans.knaw.nl/nl/life-sciences/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://dans.knaw.nl/nl/life-sciences/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://dans.knaw.nl/nl/life-sciences/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
 .
 
 eden://harvester/re3data/https://dans.knaw.nl/nl/social-sciences-and-humanities/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/re3data/https://dans.knaw.nl/nl/social-sciences-and-humanities/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://dans.knaw.nl/nl/social-sciences-and-humanities/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://dans.knaw.nl/nl/social-sciences-and-humanities/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://dans.knaw.nl/nl/social-sciences-and-humanities/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://dans.knaw.nl/nl/social-sciences-and-humanities/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://dans.knaw.nl/nl/social-sciences-and-humanities/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://dans.knaw.nl/nl/social-sciences-and-humanities/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://dans.knaw.nl/nl/social-sciences-and-humanities/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://dans.knaw.nl/nl/social-sciences-and-humanities/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -4522,27 +16649,74 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 eden://harvester/re3data/https://dass.credi.ba/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/re3data/https://dass.credi.ba/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://dass.credi.ba/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://dass.credi.ba/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+  ex:usesProperty vcard:url ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://dass.credi.ba/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://dass.credi.ba/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://dass.credi.ba/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://dass.credi.ba/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://dass.credi.ba/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -4550,27 +16724,82 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 eden://harvester/re3data/https://data.4tu.nl/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/re3data/https://data.4tu.nl/>"@en .
+
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://data.4tu.nl/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://data.4tu.nl/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+  ex:usesProperty vcard:url ;
+.
 
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://data.4tu.nl/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://data.4tu.nl/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://data.4tu.nl/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://data.4tu.nl/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://data.4tu.nl/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://data.4tu.nl/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -4578,28 +16807,83 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 eden://harvester/re3data/https://data.dtu.dk/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/re3data/https://data.dtu.dk/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://data.dtu.dk/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://data.dtu.dk/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+  ex:usesProperty vcard:url ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://data.dtu.dk/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://data.dtu.dk/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://data.dtu.dk/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://data.dtu.dk/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://data.dtu.dk/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://data.dtu.dk/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -4607,51 +16891,166 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 eden://harvester/re3data/https://data.progedo.fr/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/re3data/https://data.progedo.fr/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://data.progedo.fr/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://data.progedo.fr/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+  ex:usesProperty vcard:url ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://data.progedo.fr/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://data.progedo.fr/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://data.progedo.fr/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://data.progedo.fr/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://data.progedo.fr/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://data.progedo.fr/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://data.progedo.fr/ ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
 .
 
 eden://harvester/re3data/https://data.sciencespo.fr/dataverse/cdsp a ex:NamedGraph ;
   rdfs:label "<eden://harvester/re3data/https://data.sciencespo.fr/dataverse/cdsp>"@en .
+
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://data.sciencespo.fr/dataverse/cdsp ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://data.sciencespo.fr/dataverse/cdsp ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
 
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://data.sciencespo.fr/dataverse/cdsp ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://data.sciencespo.fr/dataverse/cdsp ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://data.sciencespo.fr/dataverse/cdsp ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://data.sciencespo.fr/dataverse/cdsp ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://data.sciencespo.fr/dataverse/cdsp ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://data.sciencespo.fr/dataverse/cdsp ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -4659,28 +17058,82 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 eden://harvester/re3data/https://datarepositorium.uminho.pt/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/re3data/https://datarepositorium.uminho.pt/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://datarepositorium.uminho.pt/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://datarepositorium.uminho.pt/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://datarepositorium.uminho.pt/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://datarepositorium.uminho.pt/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://datarepositorium.uminho.pt/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://datarepositorium.uminho.pt/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://datarepositorium.uminho.pt/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://datarepositorium.uminho.pt/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -4688,27 +17141,74 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 eden://harvester/re3data/https://dataservices.gfz-potsdam.de/web/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/re3data/https://dataservices.gfz-potsdam.de/web/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://dataservices.gfz-potsdam.de/web/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://dataservices.gfz-potsdam.de/web/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+  ex:usesProperty vcard:url ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://dataservices.gfz-potsdam.de/web/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://dataservices.gfz-potsdam.de/web/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://dataservices.gfz-potsdam.de/web/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://dataservices.gfz-potsdam.de/web/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://dataservices.gfz-potsdam.de/web/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -4716,27 +17216,82 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 eden://harvester/re3data/https://dataverse.no/dataverse/trolling a ex:NamedGraph ;
   rdfs:label "<eden://harvester/re3data/https://dataverse.no/dataverse/trolling>"@en .
+
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://dataverse.no/dataverse/trolling ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://dataverse.no/dataverse/trolling ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+  ex:usesProperty vcard:url ;
+.
 
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://dataverse.no/dataverse/trolling ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://dataverse.no/dataverse/trolling ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://dataverse.no/dataverse/trolling ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://dataverse.no/dataverse/trolling ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://dataverse.no/dataverse/trolling ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://dataverse.no/dataverse/trolling ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -4744,28 +17299,82 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 eden://harvester/re3data/https://datice.is/is a ex:NamedGraph ;
   rdfs:label "<eden://harvester/re3data/https://datice.is/is>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://datice.is/is ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://datice.is/is ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://datice.is/is ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://datice.is/is ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://datice.is/is ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://datice.is/is ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://datice.is/is ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://datice.is/is ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -4773,28 +17382,82 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 eden://harvester/re3data/https://dv.dataverse.lv/dataverse/root a ex:NamedGraph ;
   rdfs:label "<eden://harvester/re3data/https://dv.dataverse.lv/dataverse/root>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://dv.dataverse.lv/dataverse/root ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://dv.dataverse.lv/dataverse/root ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://dv.dataverse.lv/dataverse/root ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://dv.dataverse.lv/dataverse/root ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://dv.dataverse.lv/dataverse/root ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://dv.dataverse.lv/dataverse/root ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://dv.dataverse.lv/dataverse/root ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://dv.dataverse.lv/dataverse/root ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -4802,28 +17465,82 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 eden://harvester/re3data/https://ega-archive.org/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/re3data/https://ega-archive.org/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://ega-archive.org/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://ega-archive.org/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:url ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://ega-archive.org/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://ega-archive.org/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://ega-archive.org/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://ega-archive.org/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://ega-archive.org/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://ega-archive.org/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -4831,27 +17548,74 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 eden://harvester/re3data/https://gude.uni-frankfurt.de/home a ex:NamedGraph ;
   rdfs:label "<eden://harvester/re3data/https://gude.uni-frankfurt.de/home>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://gude.uni-frankfurt.de/home ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://gude.uni-frankfurt.de/home ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+  ex:usesProperty vcard:url ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://gude.uni-frankfurt.de/home ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://gude.uni-frankfurt.de/home ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://gude.uni-frankfurt.de/home ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://gude.uni-frankfurt.de/home ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://gude.uni-frankfurt.de/home ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -4859,27 +17623,82 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 eden://harvester/re3data/https://inspirehep.net/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/re3data/https://inspirehep.net/>"@en .
+
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://inspirehep.net/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://inspirehep.net/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+  ex:usesProperty vcard:url ;
+.
 
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://inspirehep.net/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://inspirehep.net/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://inspirehep.net/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://inspirehep.net/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://inspirehep.net/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://inspirehep.net/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -4887,51 +17706,166 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 eden://harvester/re3data/https://lida.dataverse.lt/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/re3data/https://lida.dataverse.lt/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://lida.dataverse.lt/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://lida.dataverse.lt/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+  ex:usesProperty vcard:url ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://lida.dataverse.lt/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://lida.dataverse.lt/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://lida.dataverse.lt/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://lida.dataverse.lt/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://lida.dataverse.lt/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://lida.dataverse.lt/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://lida.dataverse.lt/ ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
 .
 
 eden://harvester/re3data/https://lindat.mff.cuni.cz/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/re3data/https://lindat.mff.cuni.cz/>"@en .
+
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://lindat.mff.cuni.cz/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://lindat.mff.cuni.cz/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
 
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://lindat.mff.cuni.cz/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://lindat.mff.cuni.cz/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://lindat.mff.cuni.cz/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://lindat.mff.cuni.cz/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://lindat.mff.cuni.cz/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://lindat.mff.cuni.cz/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -4939,28 +17873,82 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 eden://harvester/re3data/https://opendata.nas.gov.ua/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/re3data/https://opendata.nas.gov.ua/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://opendata.nas.gov.ua/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://opendata.nas.gov.ua/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://opendata.nas.gov.ua/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://opendata.nas.gov.ua/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://opendata.nas.gov.ua/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://opendata.nas.gov.ua/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://opendata.nas.gov.ua/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://opendata.nas.gov.ua/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -4968,28 +17956,83 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 eden://harvester/re3data/https://pangaea.de/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/re3data/https://pangaea.de/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://pangaea.de/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://pangaea.de/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+  ex:usesProperty vcard:url ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://pangaea.de/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://pangaea.de/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://pangaea.de/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://pangaea.de/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://pangaea.de/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://pangaea.de/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -4997,28 +18040,83 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 eden://harvester/re3data/https://qdr.syr.edu/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/re3data/https://qdr.syr.edu/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://qdr.syr.edu/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://qdr.syr.edu/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+  ex:usesProperty vcard:url ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://qdr.syr.edu/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://qdr.syr.edu/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://qdr.syr.edu/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://qdr.syr.edu/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://qdr.syr.edu/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://qdr.syr.edu/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -5026,26 +18124,83 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 eden://harvester/re3data/https://radar.brookes.ac.uk/radar/hierarchy.do?topic=86e2c9d7-ef43-4b54-a387-3223d30acd3b a ex:NamedGraph ;
   rdfs:label "<eden://harvester/re3data/https://radar.brookes.ac.uk/radar/hierarchy.do?topic=86e2c9d7-ef43-4b54-a387-3223d30acd3b>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://radar.brookes.ac.uk/radar/hierarchy.do?topic=86e2c9d7-ef43-4b54-a387-3223d30acd3b ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://radar.brookes.ac.uk/radar/hierarchy.do?topic=86e2c9d7-ef43-4b54-a387-3223d30acd3b ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+  ex:usesProperty vcard:url ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://radar.brookes.ac.uk/radar/hierarchy.do?topic=86e2c9d7-ef43-4b54-a387-3223d30acd3b ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://radar.brookes.ac.uk/radar/hierarchy.do?topic=86e2c9d7-ef43-4b54-a387-3223d30acd3b ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://radar.brookes.ac.uk/radar/hierarchy.do?topic=86e2c9d7-ef43-4b54-a387-3223d30acd3b ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://radar.brookes.ac.uk/radar/hierarchy.do?topic=86e2c9d7-ef43-4b54-a387-3223d30acd3b ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://radar.brookes.ac.uk/radar/hierarchy.do?topic=86e2c9d7-ef43-4b54-a387-3223d30acd3b ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://radar.brookes.ac.uk/radar/hierarchy.do?topic=86e2c9d7-ef43-4b54-a387-3223d30acd3b ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -5053,26 +18208,82 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
 .
 
 eden://harvester/re3data/https://radar.ibiss.bg.ac.rs/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/re3data/https://radar.ibiss.bg.ac.rs/>"@en .
+
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://radar.ibiss.bg.ac.rs/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://radar.ibiss.bg.ac.rs/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
 
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://radar.ibiss.bg.ac.rs/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://radar.ibiss.bg.ac.rs/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://radar.ibiss.bg.ac.rs/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://radar.ibiss.bg.ac.rs/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://radar.ibiss.bg.ac.rs/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://radar.ibiss.bg.ac.rs/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -5080,28 +18291,82 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 eden://harvester/re3data/https://rdr.kuleuven.be/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/re3data/https://rdr.kuleuven.be/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://rdr.kuleuven.be/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://rdr.kuleuven.be/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://rdr.kuleuven.be/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://rdr.kuleuven.be/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://rdr.kuleuven.be/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://rdr.kuleuven.be/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://rdr.kuleuven.be/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://rdr.kuleuven.be/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -5109,28 +18374,83 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 eden://harvester/re3data/https://reactome.org/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/re3data/https://reactome.org/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://reactome.org/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://reactome.org/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+  ex:usesProperty vcard:url ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://reactome.org/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://reactome.org/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://reactome.org/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://reactome.org/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://reactome.org/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://reactome.org/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -5138,28 +18458,82 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 eden://harvester/re3data/https://recherche.data.gouv.fr/en/page/about-recherche-data-gouv a ex:NamedGraph ;
   rdfs:label "<eden://harvester/re3data/https://recherche.data.gouv.fr/en/page/about-recherche-data-gouv>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://recherche.data.gouv.fr/en/page/about-recherche-data-gouv ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://recherche.data.gouv.fr/en/page/about-recherche-data-gouv ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:url ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://recherche.data.gouv.fr/en/page/about-recherche-data-gouv ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://recherche.data.gouv.fr/en/page/about-recherche-data-gouv ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://recherche.data.gouv.fr/en/page/about-recherche-data-gouv ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://recherche.data.gouv.fr/en/page/about-recherche-data-gouv ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://recherche.data.gouv.fr/en/page/about-recherche-data-gouv ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://recherche.data.gouv.fr/en/page/about-recherche-data-gouv ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -5167,54 +18541,149 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 eden://harvester/re3data/https://repo.researchdata.hu/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/re3data/https://repo.researchdata.hu/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://repo.researchdata.hu/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://repo.researchdata.hu/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://repo.researchdata.hu/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://repo.researchdata.hu/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://repo.researchdata.hu/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://repo.researchdata.hu/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://repo.researchdata.hu/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://repo.researchdata.hu/ ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 eden://harvester/re3data/https://rivec.institut-palanka.rs/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/re3data/https://rivec.institut-palanka.rs/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://rivec.institut-palanka.rs/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://rivec.institut-palanka.rs/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+  ex:usesProperty vcard:url ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://rivec.institut-palanka.rs/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://rivec.institut-palanka.rs/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://rivec.institut-palanka.rs/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://rivec.institut-palanka.rs/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://rivec.institut-palanka.rs/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -5222,26 +18691,72 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 eden://harvester/re3data/https://sasd.sav.sk/en/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/re3data/https://sasd.sav.sk/en/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://sasd.sav.sk/en/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://sasd.sav.sk/en/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:url ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://sasd.sav.sk/en/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://sasd.sav.sk/en/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://sasd.sav.sk/en/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://sasd.sav.sk/en/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://sasd.sav.sk/en/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -5249,7 +18764,13 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 eden://harvester/re3data/https://sikt.no/en/archiving-research-data a ex:NamedGraph ;
@@ -5260,7 +18781,20 @@ ex:typeProfile_Policy a ex:TypeProfile ;
   ex:nodeType dct:Policy ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://sikt.no/en/archiving-research-data ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+  ex:usesProperty vcard:url ;
 .
 
 ex:typeProfile_Catalog a ex:TypeProfile ;
@@ -5268,15 +18802,43 @@ ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://sikt.no/en/archiving-research-data ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://sikt.no/en/archiving-research-data ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://sikt.no/en/archiving-research-data ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://sikt.no/en/archiving-research-data ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -5284,27 +18846,81 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 eden://harvester/re3data/https://string-db.org/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/re3data/https://string-db.org/>"@en .
+
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://string-db.org/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://string-db.org/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:url ;
+.
 
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://string-db.org/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://string-db.org/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://string-db.org/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://string-db.org/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://string-db.org/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://string-db.org/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -5312,28 +18928,82 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 eden://harvester/re3data/https://ukdataservice.ac.uk/about/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/re3data/https://ukdataservice.ac.uk/about/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://ukdataservice.ac.uk/about/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://ukdataservice.ac.uk/about/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:url ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://ukdataservice.ac.uk/about/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://ukdataservice.ac.uk/about/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://ukdataservice.ac.uk/about/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://ukdataservice.ac.uk/about/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://ukdataservice.ac.uk/about/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://ukdataservice.ac.uk/about/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -5341,28 +19011,83 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 eden://harvester/re3data/https://www.adp.fdv.uni-lj.si/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/re3data/https://www.adp.fdv.uni-lj.si/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.adp.fdv.uni-lj.si/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.adp.fdv.uni-lj.si/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+  ex:usesProperty vcard:url ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://www.adp.fdv.uni-lj.si/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://www.adp.fdv.uni-lj.si/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.adp.fdv.uni-lj.si/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.adp.fdv.uni-lj.si/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.adp.fdv.uni-lj.si/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.adp.fdv.uni-lj.si/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -5370,28 +19095,82 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 eden://harvester/re3data/https://www.bgee.org/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/re3data/https://www.bgee.org/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.bgee.org/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.bgee.org/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://www.bgee.org/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://www.bgee.org/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.bgee.org/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.bgee.org/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.bgee.org/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.bgee.org/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -5399,28 +19178,82 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 eden://harvester/re3data/https://www.cathdb.info/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/re3data/https://www.cathdb.info/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.cathdb.info/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.cathdb.info/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+  ex:usesProperty vcard:url ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://www.cathdb.info/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://www.cathdb.info/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.cathdb.info/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.cathdb.info/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.cathdb.info/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.cathdb.info/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -5428,55 +19261,158 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 eden://harvester/re3data/https://www.cellosaurus.org/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/re3data/https://www.cellosaurus.org/>"@en .
 
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.cellosaurus.org/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+  ex:usesProperty vcard:url ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://www.cellosaurus.org/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://www.cellosaurus.org/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.cellosaurus.org/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.cellosaurus.org/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.cellosaurus.org/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.cellosaurus.org/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://www.cellosaurus.org/ ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 eden://harvester/re3data/https://www.clarin.eu/content/national-consortia a ex:NamedGraph ;
   rdfs:label "<eden://harvester/re3data/https://www.clarin.eu/content/national-consortia>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.clarin.eu/content/national-consortia ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.clarin.eu/content/national-consortia ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://www.clarin.eu/content/national-consortia ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://www.clarin.eu/content/national-consortia ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.clarin.eu/content/national-consortia ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.clarin.eu/content/national-consortia ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.clarin.eu/content/national-consortia ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.clarin.eu/content/national-consortia ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -5484,51 +19420,166 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 eden://harvester/re3data/https://www.crossda.hr/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/re3data/https://www.crossda.hr/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.crossda.hr/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.crossda.hr/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://www.crossda.hr/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://www.crossda.hr/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.crossda.hr/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.crossda.hr/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.crossda.hr/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.crossda.hr/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://www.crossda.hr/ ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
 .
 
 eden://harvester/re3data/https://www.ebi.ac.uk/bioimage-archive/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/re3data/https://www.ebi.ac.uk/bioimage-archive/>"@en .
+
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/bioimage-archive/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/bioimage-archive/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+  ex:usesProperty vcard:url ;
+.
 
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/bioimage-archive/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/bioimage-archive/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/bioimage-archive/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/bioimage-archive/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/bioimage-archive/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/bioimage-archive/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -5536,28 +19587,83 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 eden://harvester/re3data/https://www.ebi.ac.uk/biosamples/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/re3data/https://www.ebi.ac.uk/biosamples/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/biosamples/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/biosamples/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+  ex:usesProperty vcard:url ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/biosamples/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/biosamples/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/biosamples/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/biosamples/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/biosamples/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/biosamples/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -5565,28 +19671,83 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 eden://harvester/re3data/https://www.ebi.ac.uk/biostudies/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/re3data/https://www.ebi.ac.uk/biostudies/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/biostudies/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/biostudies/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+  ex:usesProperty vcard:url ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/biostudies/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/biostudies/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/biostudies/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/biostudies/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/biostudies/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/biostudies/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -5594,28 +19755,83 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 eden://harvester/re3data/https://www.ebi.ac.uk/biostudies/arrayexpress a ex:NamedGraph ;
   rdfs:label "<eden://harvester/re3data/https://www.ebi.ac.uk/biostudies/arrayexpress>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/biostudies/arrayexpress ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/biostudies/arrayexpress ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+  ex:usesProperty vcard:url ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/biostudies/arrayexpress ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/biostudies/arrayexpress ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/biostudies/arrayexpress ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/biostudies/arrayexpress ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/biostudies/arrayexpress ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/biostudies/arrayexpress ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -5623,28 +19839,83 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 eden://harvester/re3data/https://www.ebi.ac.uk/chembl/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/re3data/https://www.ebi.ac.uk/chembl/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/chembl/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/chembl/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+  ex:usesProperty vcard:url ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/chembl/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/chembl/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/chembl/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/chembl/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/chembl/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/chembl/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -5652,28 +19923,83 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 eden://harvester/re3data/https://www.ebi.ac.uk/emdb/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/re3data/https://www.ebi.ac.uk/emdb/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/emdb/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/emdb/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+  ex:usesProperty vcard:url ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/emdb/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/emdb/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/emdb/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/emdb/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/emdb/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/emdb/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -5681,28 +20007,83 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 eden://harvester/re3data/https://www.ebi.ac.uk/empiar/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/re3data/https://www.ebi.ac.uk/empiar/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/empiar/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/empiar/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+  ex:usesProperty vcard:url ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/empiar/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/empiar/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/empiar/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/empiar/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/empiar/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/empiar/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -5710,28 +20091,83 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 eden://harvester/re3data/https://www.ebi.ac.uk/ena/browser/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/re3data/https://www.ebi.ac.uk/ena/browser/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/ena/browser/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/ena/browser/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+  ex:usesProperty vcard:url ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/ena/browser/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/ena/browser/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/ena/browser/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/ena/browser/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/ena/browser/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/ena/browser/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -5739,28 +20175,83 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 eden://harvester/re3data/https://www.ebi.ac.uk/eva/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/re3data/https://www.ebi.ac.uk/eva/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/eva/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/eva/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+  ex:usesProperty vcard:url ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/eva/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/eva/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/eva/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/eva/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/eva/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/eva/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -5768,28 +20259,83 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 eden://harvester/re3data/https://www.ebi.ac.uk/gwas/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/re3data/https://www.ebi.ac.uk/gwas/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/gwas/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/gwas/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+  ex:usesProperty vcard:url ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/gwas/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/gwas/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/gwas/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/gwas/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/gwas/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/gwas/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -5797,28 +20343,83 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 eden://harvester/re3data/https://www.ebi.ac.uk/intact/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/re3data/https://www.ebi.ac.uk/intact/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/intact/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/intact/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+  ex:usesProperty vcard:url ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/intact/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/intact/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/intact/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/intact/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/intact/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/intact/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -5826,28 +20427,83 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 eden://harvester/re3data/https://www.ebi.ac.uk/metabolights/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/re3data/https://www.ebi.ac.uk/metabolights/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/metabolights/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/metabolights/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+  ex:usesProperty vcard:url ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/metabolights/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/metabolights/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/metabolights/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/metabolights/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/metabolights/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/metabolights/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -5855,28 +20511,83 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 eden://harvester/re3data/https://www.ebi.ac.uk/pdbe/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/re3data/https://www.ebi.ac.uk/pdbe/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/pdbe/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/pdbe/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+  ex:usesProperty vcard:url ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/pdbe/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/pdbe/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/pdbe/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/pdbe/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/pdbe/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/pdbe/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -5884,28 +20595,83 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 eden://harvester/re3data/https://www.ebi.ac.uk/pride/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/re3data/https://www.ebi.ac.uk/pride/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/pride/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/pride/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+  ex:usesProperty vcard:url ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/pride/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/pride/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/pride/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/pride/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/pride/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ebi.ac.uk/pride/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -5913,28 +20679,166 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+.
+
+eden://harvester/re3data/https://www.fairdata.fi/ a ex:NamedGraph ;
+  rdfs:label "<eden://harvester/re3data/https://www.fairdata.fi/>"@en .
+
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.fairdata.fi/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.fairdata.fi/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
+ex:typeProfile_Catalog a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.fairdata.fi/ ;
+  ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
+.
+
+ex:typeProfile_CatalogRecord a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.fairdata.fi/ ;
+  ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
+  ex:usesProperty prov:wasAssociatedWith ;
+  ex:usesProperty prov:wasGeneratedBy ;
+  ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.fairdata.fi/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.fairdata.fi/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.fairdata.fi/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.fairdata.fi/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
+.
+
+ex:typeProfile_Project a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.fairdata.fi/ ;
+  ex:nodeType foaf:Project ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 eden://harvester/re3data/https://www.fsd.tuni.fi/en/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/re3data/https://www.fsd.tuni.fi/en/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.fsd.tuni.fi/en/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.fsd.tuni.fi/en/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+  ex:usesProperty vcard:url ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://www.fsd.tuni.fi/en/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://www.fsd.tuni.fi/en/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.fsd.tuni.fi/en/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.fsd.tuni.fi/en/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.fsd.tuni.fi/en/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.fsd.tuni.fi/en/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -5942,28 +20846,83 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 eden://harvester/re3data/https://www.kielipankki.fi/language-bank/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/re3data/https://www.kielipankki.fi/language-bank/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.kielipankki.fi/language-bank/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.kielipankki.fi/language-bank/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+  ex:usesProperty vcard:url ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://www.kielipankki.fi/language-bank/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://www.kielipankki.fi/language-bank/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.kielipankki.fi/language-bank/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.kielipankki.fi/language-bank/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.kielipankki.fi/language-bank/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.kielipankki.fi/language-bank/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -5971,27 +20930,74 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 eden://harvester/re3data/https://www.ldc.upenn.edu/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/re3data/https://www.ldc.upenn.edu/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ldc.upenn.edu/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ldc.upenn.edu/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+  ex:usesProperty vcard:url ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://www.ldc.upenn.edu/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://www.ldc.upenn.edu/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ldc.upenn.edu/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ldc.upenn.edu/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ldc.upenn.edu/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -5999,27 +21005,81 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 eden://harvester/re3data/https://www.lipidmaps.org/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/re3data/https://www.lipidmaps.org/>"@en .
+
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.lipidmaps.org/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.lipidmaps.org/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:url ;
+.
 
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://www.lipidmaps.org/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://www.lipidmaps.org/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.lipidmaps.org/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.lipidmaps.org/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.lipidmaps.org/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.lipidmaps.org/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -6027,27 +21087,74 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 eden://harvester/re3data/https://www.ortolang.fr/en/home/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/re3data/https://www.ortolang.fr/en/home/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ortolang.fr/en/home/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ortolang.fr/en/home/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+  ex:usesProperty vcard:url ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://www.ortolang.fr/en/home/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://www.ortolang.fr/en/home/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ortolang.fr/en/home/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ortolang.fr/en/home/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.ortolang.fr/en/home/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -6055,27 +21162,82 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 eden://harvester/re3data/https://www.paradisec.org.au/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/re3data/https://www.paradisec.org.au/>"@en .
+
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.paradisec.org.au/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.paradisec.org.au/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+  ex:usesProperty vcard:url ;
+.
 
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://www.paradisec.org.au/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://www.paradisec.org.au/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.paradisec.org.au/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.paradisec.org.au/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.paradisec.org.au/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.paradisec.org.au/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -6083,51 +21245,166 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 eden://harvester/re3data/https://www.progedo.fr/en/home/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/re3data/https://www.progedo.fr/en/home/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.progedo.fr/en/home/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.progedo.fr/en/home/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+  ex:usesProperty vcard:url ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://www.progedo.fr/en/home/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://www.progedo.fr/en/home/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.progedo.fr/en/home/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.progedo.fr/en/home/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.progedo.fr/en/home/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.progedo.fr/en/home/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://www.progedo.fr/en/home/ ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+  ex:usesProperty dcat:service ;
 .
 
 eden://harvester/re3data/https://www.rohub.org/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/re3data/https://www.rohub.org/>"@en .
+
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.rohub.org/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.rohub.org/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
 
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://www.rohub.org/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://www.rohub.org/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.rohub.org/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.rohub.org/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.rohub.org/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.rohub.org/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -6135,28 +21412,82 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 eden://harvester/re3data/https://www.sodha.be/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/re3data/https://www.sodha.be/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.sodha.be/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.sodha.be/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://www.sodha.be/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://www.sodha.be/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.sodha.be/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.sodha.be/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.sodha.be/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.sodha.be/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -6164,28 +21495,83 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 eden://harvester/re3data/https://www.storedb.org/store_v3/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/re3data/https://www.storedb.org/store_v3/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.storedb.org/store_v3/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.storedb.org/store_v3/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+  ex:usesProperty vcard:url ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://www.storedb.org/store_v3/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://www.storedb.org/store_v3/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.storedb.org/store_v3/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.storedb.org/store_v3/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.storedb.org/store_v3/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.storedb.org/store_v3/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -6193,27 +21579,73 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 eden://harvester/re3data/https://www.tarki.hu/eng a ex:NamedGraph ;
   rdfs:label "<eden://harvester/re3data/https://www.tarki.hu/eng>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.tarki.hu/eng ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.tarki.hu/eng ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://www.tarki.hu/eng ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://www.tarki.hu/eng ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.tarki.hu/eng ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.tarki.hu/eng ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.tarki.hu/eng ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -6221,27 +21653,81 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
 .
 
 eden://harvester/re3data/https://www.uniprot.org/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/re3data/https://www.uniprot.org/>"@en .
+
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.uniprot.org/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.uniprot.org/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:url ;
+.
 
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://www.uniprot.org/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://www.uniprot.org/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.uniprot.org/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.uniprot.org/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.uniprot.org/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.uniprot.org/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -6249,28 +21735,82 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 eden://harvester/re3data/https://www.wdc-climate.de/ui/ a ex:NamedGraph ;
   rdfs:label "<eden://harvester/re3data/https://www.wdc-climate.de/ui/>"@en .
 
+ex:typeProfile_Policy a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.wdc-climate.de/ui/ ;
+  ex:nodeType dct:Policy ;
+  ex:usesProperty dct:title ;
+.
+
+ex:typeProfile_Kind a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.wdc-climate.de/ui/ ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+.
+
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://www.wdc-climate.de/ui/ ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/re3data/https://www.wdc-climate.de/ui/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.wdc-climate.de/ui/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.wdc-climate.de/ui/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.wdc-climate.de/ui/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:typeProfile_Agent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/re3data/https://www.wdc-climate.de/ui/ ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
@@ -6278,7 +21818,13 @@ ex:typeProfile_Project a ex:TypeProfile ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
 .
 
@@ -6288,20 +21834,44 @@ eden://harvester/sitemap_service/https://borealisdata.ca/ a ex:NamedGraph ;
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/sitemap_service/https://borealisdata.ca/ ;
   ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/sitemap_service/https://borealisdata.ca/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
 .
 
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/sitemap_service/https://borealisdata.ca/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:format ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/sitemap_service/https://borealisdata.ca/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/sitemap_service/https://borealisdata.ca/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
 ex:typeProfile_Project a ex:TypeProfile ;
   ex:inGraph eden://harvester/sitemap_service/https://borealisdata.ca/ ;
   ex:nodeType foaf:Project ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dcat:service ;
 .
 
@@ -6311,20 +21881,44 @@ eden://harvester/sitemap_service/https://cds.climate.copernicus.eu/ a ex:NamedGr
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/sitemap_service/https://cds.climate.copernicus.eu/ ;
   ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/sitemap_service/https://cds.climate.copernicus.eu/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
 .
 
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/sitemap_service/https://cds.climate.copernicus.eu/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:format ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/sitemap_service/https://cds.climate.copernicus.eu/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/sitemap_service/https://cds.climate.copernicus.eu/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
 ex:typeProfile_Project a ex:TypeProfile ;
   ex:inGraph eden://harvester/sitemap_service/https://cds.climate.copernicus.eu/ ;
   ex:nodeType foaf:Project ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dcat:service ;
 .
 
@@ -6334,20 +21928,44 @@ eden://harvester/sitemap_service/https://cds.unistra.fr/ a ex:NamedGraph ;
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/sitemap_service/https://cds.unistra.fr/ ;
   ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/sitemap_service/https://cds.unistra.fr/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
 .
 
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/sitemap_service/https://cds.unistra.fr/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:format ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/sitemap_service/https://cds.unistra.fr/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/sitemap_service/https://cds.unistra.fr/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
 ex:typeProfile_Project a ex:TypeProfile ;
   ex:inGraph eden://harvester/sitemap_service/https://cds.unistra.fr/ ;
   ex:nodeType foaf:Project ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dcat:service ;
 .
 
@@ -6357,20 +21975,44 @@ eden://harvester/sitemap_service/https://data.4tu.nl/ a ex:NamedGraph ;
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/sitemap_service/https://data.4tu.nl/ ;
   ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/sitemap_service/https://data.4tu.nl/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
 .
 
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/sitemap_service/https://data.4tu.nl/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:format ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/sitemap_service/https://data.4tu.nl/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/sitemap_service/https://data.4tu.nl/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
 ex:typeProfile_Project a ex:TypeProfile ;
   ex:inGraph eden://harvester/sitemap_service/https://data.4tu.nl/ ;
   ex:nodeType foaf:Project ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dcat:service ;
 .
 
@@ -6380,20 +22022,44 @@ eden://harvester/sitemap_service/https://inspirehep.net/ a ex:NamedGraph ;
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/sitemap_service/https://inspirehep.net/ ;
   ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/sitemap_service/https://inspirehep.net/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
 .
 
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/sitemap_service/https://inspirehep.net/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:format ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/sitemap_service/https://inspirehep.net/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/sitemap_service/https://inspirehep.net/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
 ex:typeProfile_Project a ex:TypeProfile ;
   ex:inGraph eden://harvester/sitemap_service/https://inspirehep.net/ ;
   ex:nodeType foaf:Project ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dcat:service ;
 .
 
@@ -6403,20 +22069,44 @@ eden://harvester/sitemap_service/https://lindat.mff.cuni.cz/ a ex:NamedGraph ;
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/sitemap_service/https://lindat.mff.cuni.cz/ ;
   ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/sitemap_service/https://lindat.mff.cuni.cz/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
 .
 
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/sitemap_service/https://lindat.mff.cuni.cz/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:format ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/sitemap_service/https://lindat.mff.cuni.cz/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/sitemap_service/https://lindat.mff.cuni.cz/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
 ex:typeProfile_Project a ex:TypeProfile ;
   ex:inGraph eden://harvester/sitemap_service/https://lindat.mff.cuni.cz/ ;
   ex:nodeType foaf:Project ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dcat:service ;
 .
 
@@ -6426,20 +22116,44 @@ eden://harvester/sitemap_service/https://naehrwertdaten.ch/de/ a ex:NamedGraph ;
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/sitemap_service/https://naehrwertdaten.ch/de/ ;
   ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/sitemap_service/https://naehrwertdaten.ch/de/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
 .
 
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/sitemap_service/https://naehrwertdaten.ch/de/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:format ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/sitemap_service/https://naehrwertdaten.ch/de/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/sitemap_service/https://naehrwertdaten.ch/de/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
 ex:typeProfile_Project a ex:TypeProfile ;
   ex:inGraph eden://harvester/sitemap_service/https://naehrwertdaten.ch/de/ ;
   ex:nodeType foaf:Project ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dcat:service ;
 .
 
@@ -6449,20 +22163,44 @@ eden://harvester/sitemap_service/https://rdr.kuleuven.be/ a ex:NamedGraph ;
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/sitemap_service/https://rdr.kuleuven.be/ ;
   ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/sitemap_service/https://rdr.kuleuven.be/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
 .
 
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/sitemap_service/https://rdr.kuleuven.be/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:format ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/sitemap_service/https://rdr.kuleuven.be/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/sitemap_service/https://rdr.kuleuven.be/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
 ex:typeProfile_Project a ex:TypeProfile ;
   ex:inGraph eden://harvester/sitemap_service/https://rdr.kuleuven.be/ ;
   ex:nodeType foaf:Project ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dcat:service ;
 .
 
@@ -6472,20 +22210,44 @@ eden://harvester/sitemap_service/https://reactome.org/ a ex:NamedGraph ;
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/sitemap_service/https://reactome.org/ ;
   ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/sitemap_service/https://reactome.org/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
 .
 
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/sitemap_service/https://reactome.org/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:format ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/sitemap_service/https://reactome.org/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/sitemap_service/https://reactome.org/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
 ex:typeProfile_Project a ex:TypeProfile ;
   ex:inGraph eden://harvester/sitemap_service/https://reactome.org/ ;
   ex:nodeType foaf:Project ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dcat:service ;
 .
 
@@ -6495,20 +22257,44 @@ eden://harvester/sitemap_service/https://repo.researchdata.hu/ a ex:NamedGraph ;
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/sitemap_service/https://repo.researchdata.hu/ ;
   ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/sitemap_service/https://repo.researchdata.hu/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
 .
 
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/sitemap_service/https://repo.researchdata.hu/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:format ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/sitemap_service/https://repo.researchdata.hu/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/sitemap_service/https://repo.researchdata.hu/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
 ex:typeProfile_Project a ex:TypeProfile ;
   ex:inGraph eden://harvester/sitemap_service/https://repo.researchdata.hu/ ;
   ex:nodeType foaf:Project ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dcat:service ;
 .
 
@@ -6518,20 +22304,44 @@ eden://harvester/sitemap_service/https://www.adp.fdv.uni-lj.si/ a ex:NamedGraph 
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/sitemap_service/https://www.adp.fdv.uni-lj.si/ ;
   ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/sitemap_service/https://www.adp.fdv.uni-lj.si/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
 .
 
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/sitemap_service/https://www.adp.fdv.uni-lj.si/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:format ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/sitemap_service/https://www.adp.fdv.uni-lj.si/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/sitemap_service/https://www.adp.fdv.uni-lj.si/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
 ex:typeProfile_Project a ex:TypeProfile ;
   ex:inGraph eden://harvester/sitemap_service/https://www.adp.fdv.uni-lj.si/ ;
   ex:nodeType foaf:Project ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dcat:service ;
 .
 
@@ -6541,20 +22351,44 @@ eden://harvester/sitemap_service/https://www.bgee.org/ a ex:NamedGraph ;
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/sitemap_service/https://www.bgee.org/ ;
   ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/sitemap_service/https://www.bgee.org/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
 .
 
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/sitemap_service/https://www.bgee.org/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:format ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/sitemap_service/https://www.bgee.org/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/sitemap_service/https://www.bgee.org/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
 ex:typeProfile_Project a ex:TypeProfile ;
   ex:inGraph eden://harvester/sitemap_service/https://www.bgee.org/ ;
   ex:nodeType foaf:Project ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dcat:service ;
 .
 
@@ -6564,20 +22398,44 @@ eden://harvester/sitemap_service/https://www.cellosaurus.org/ a ex:NamedGraph ;
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/sitemap_service/https://www.cellosaurus.org/ ;
   ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/sitemap_service/https://www.cellosaurus.org/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
 .
 
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/sitemap_service/https://www.cellosaurus.org/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:format ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/sitemap_service/https://www.cellosaurus.org/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/sitemap_service/https://www.cellosaurus.org/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
 ex:typeProfile_Project a ex:TypeProfile ;
   ex:inGraph eden://harvester/sitemap_service/https://www.cellosaurus.org/ ;
   ex:nodeType foaf:Project ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dcat:service ;
 .
 
@@ -6587,20 +22445,44 @@ eden://harvester/sitemap_service/https://www.fairdata.fi/ a ex:NamedGraph ;
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/sitemap_service/https://www.fairdata.fi/ ;
   ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/sitemap_service/https://www.fairdata.fi/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
 .
 
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/sitemap_service/https://www.fairdata.fi/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:format ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/sitemap_service/https://www.fairdata.fi/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/sitemap_service/https://www.fairdata.fi/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
 ex:typeProfile_Project a ex:TypeProfile ;
   ex:inGraph eden://harvester/sitemap_service/https://www.fairdata.fi/ ;
   ex:nodeType foaf:Project ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dcat:service ;
 .
 
@@ -6610,20 +22492,44 @@ eden://harvester/sitemap_service/https://www.lipidmaps.org/ a ex:NamedGraph ;
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/sitemap_service/https://www.lipidmaps.org/ ;
   ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/sitemap_service/https://www.lipidmaps.org/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
 .
 
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/sitemap_service/https://www.lipidmaps.org/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:format ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/sitemap_service/https://www.lipidmaps.org/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/sitemap_service/https://www.lipidmaps.org/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
 ex:typeProfile_Project a ex:TypeProfile ;
   ex:inGraph eden://harvester/sitemap_service/https://www.lipidmaps.org/ ;
   ex:nodeType foaf:Project ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dcat:service ;
 .
 
@@ -6633,203 +22539,43 @@ eden://harvester/sitemap_service/https://www.uniprot.org/ a ex:NamedGraph ;
 ex:typeProfile_Catalog a ex:TypeProfile ;
   ex:inGraph eden://harvester/sitemap_service/https://www.uniprot.org/ ;
   ex:nodeType dcat:Catalog ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dcat:service ;
 .
 
 ex:typeProfile_CatalogRecord a ex:TypeProfile ;
   ex:inGraph eden://harvester/sitemap_service/https://www.uniprot.org/ ;
   ex:nodeType dcat:CatalogRecord ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:typeProfile_DataService a ex:TypeProfile ;
+  ex:inGraph eden://harvester/sitemap_service/https://www.uniprot.org/ ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:format ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:typeProfile_Activity a ex:TypeProfile ;
+  ex:inGraph eden://harvester/sitemap_service/https://www.uniprot.org/ ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:typeProfile_SoftwareAgent a ex:TypeProfile ;
+  ex:inGraph eden://harvester/sitemap_service/https://www.uniprot.org/ ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
 .
 
 ex:typeProfile_Project a ex:TypeProfile ;
   ex:inGraph eden://harvester/sitemap_service/https://www.uniprot.org/ ;
   ex:nodeType foaf:Project ;
-  ex:usesProperty dcat:service ;
-.
-
-<https://data.ktu.edu/EN/data-archive/
-            a          dct:Policy;
-            dct:title  "Terms of use for the LiDA Dataverse repository data" .
-}
-
-<eden://harvester/harmonized/https://omabrowser.org/oma/home/> a ex:NamedGraph ;
-  rdfs:label "<https://data.ktu.edu/EN/data-archive/
-            a          dct:Policy;
-            dct:title  "Terms of use for the LiDA Dataverse repository data" .
-}
-
-<eden://harvester/harmonized/https://omabrowser.org/oma/home/>"@en .
-
-ex:typeProfile_CatalogRecord a ex:TypeProfile ;
-  ex:inGraph <https://data.ktu.edu/EN/data-archive/
-            a          dct:Policy;
-            dct:title  "Terms of use for the LiDA Dataverse repository data" .
-}
-
-<eden://harvester/harmonized/https://omabrowser.org/oma/home/> ;
-  ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dct:conformsTo ;
-  ex:usesProperty dct:contactPoint ;
-  ex:usesProperty dct:publisher ;
-  ex:usesProperty dcat:service ;
-  ex:usesProperty prov:wasAssociatedWith ;
-  ex:usesProperty prov:wasGeneratedBy ;
-  ex:usesProperty foaf:primaryTopic ;
-.
-
-<https://data.ktu.edu/EN/data-archive/
-            a          dct:Policy;
-            dct:title  "Terms of use for the LiDA Dataverse repository data" .
-}
-
-<eden://harvester/re3data/https://www.fairdata.fi/> a ex:NamedGraph ;
-  rdfs:label "<https://data.ktu.edu/EN/data-archive/
-            a          dct:Policy;
-            dct:title  "Terms of use for the LiDA Dataverse repository data" .
-}
-
-<eden://harvester/re3data/https://www.fairdata.fi/>"@en .
-
-ex:typeProfile_Catalog a ex:TypeProfile ;
-  ex:inGraph <https://data.ktu.edu/EN/data-archive/
-            a          dct:Policy;
-            dct:title  "Terms of use for the LiDA Dataverse repository data" .
-}
-
-<eden://harvester/re3data/https://www.fairdata.fi/> ;
-  ex:nodeType dcat:Catalog ;
-  ex:usesProperty dct:conformsTo ;
-  ex:usesProperty dct:contactPoint ;
-  ex:usesProperty dct:publisher ;
-  ex:usesProperty dcat:service ;
-.
-
-ex:typeProfile_CatalogRecord a ex:TypeProfile ;
-  ex:inGraph <https://data.ktu.edu/EN/data-archive/
-            a          dct:Policy;
-            dct:title  "Terms of use for the LiDA Dataverse repository data" .
-}
-
-<eden://harvester/re3data/https://www.fairdata.fi/> ;
-  ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty prov:wasAssociatedWith ;
-  ex:usesProperty prov:wasGeneratedBy ;
-  ex:usesProperty foaf:primaryTopic ;
-.
-
-ex:typeProfile_Project a ex:TypeProfile ;
-  ex:inGraph <https://data.ktu.edu/EN/data-archive/
-            a          dct:Policy;
-            dct:title  "Terms of use for the LiDA Dataverse repository data" .
-}
-
-<eden://harvester/re3data/https://www.fairdata.fi/> ;
-  ex:nodeType foaf:Project ;
-  ex:usesProperty dct:conformsTo ;
-  ex:usesProperty dct:contactPoint ;
-  ex:usesProperty dct:publisher ;
-  ex:usesProperty dcat:service ;
-.
-
-<https://www.clarin.eu/faq-page/275
-            a                 dcat:DataService;
-            dct:conformsTo    "http://www.openarchives.org/OAI/2.0/";
-            dct:title         "OAI-PMH API";
-            dcat:endpointURL  "https://www.clarin.eu/faq-page/275
-}
-
-<eden://harvester/harmonized/https://www.ebi.ac.uk/biostudies/arrayexpress> a ex:NamedGraph ;
-  rdfs:label "<https://www.clarin.eu/faq-page/275
-            a                 dcat:DataService;
-            dct:conformsTo    "http://www.openarchives.org/OAI/2.0/";
-            dct:title         "OAI-PMH API";
-            dcat:endpointURL  "https://www.clarin.eu/faq-page/275
-}
-
-<eden://harvester/harmonized/https://www.ebi.ac.uk/biostudies/arrayexpress>"@en .
-
-ex:typeProfile_CatalogRecord a ex:TypeProfile ;
-  ex:inGraph <https://www.clarin.eu/faq-page/275
-            a                 dcat:DataService;
-            dct:conformsTo    "http://www.openarchives.org/OAI/2.0/";
-            dct:title         "OAI-PMH API";
-            dcat:endpointURL  "https://www.clarin.eu/faq-page/275
-}
-
-<eden://harvester/harmonized/https://www.ebi.ac.uk/biostudies/arrayexpress> ;
-  ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dct:conformsTo ;
-  ex:usesProperty dct:contactPoint ;
-  ex:usesProperty dct:publisher ;
-  ex:usesProperty dcat:service ;
-  ex:usesProperty prov:wasAssociatedWith ;
-  ex:usesProperty prov:wasGeneratedBy ;
-  ex:usesProperty foaf:primaryTopic ;
-.
-
-<https://www.clarin.eu/faq-page/275
-            a                 dcat:DataService;
-            dct:conformsTo    "http://www.openarchives.org/OAI/2.0/";
-            dct:title         "OAI-PMH API";
-            dcat:endpointURL  "https://www.clarin.eu/faq-page/275
-}
-
-<eden://harvester/re3data/https://dans.knaw.nl/nl/life-sciences/> a ex:NamedGraph ;
-  rdfs:label "<https://www.clarin.eu/faq-page/275
-            a                 dcat:DataService;
-            dct:conformsTo    "http://www.openarchives.org/OAI/2.0/";
-            dct:title         "OAI-PMH API";
-            dcat:endpointURL  "https://www.clarin.eu/faq-page/275
-}
-
-<eden://harvester/re3data/https://dans.knaw.nl/nl/life-sciences/>"@en .
-
-ex:typeProfile_Catalog a ex:TypeProfile ;
-  ex:inGraph <https://www.clarin.eu/faq-page/275
-            a                 dcat:DataService;
-            dct:conformsTo    "http://www.openarchives.org/OAI/2.0/";
-            dct:title         "OAI-PMH API";
-            dcat:endpointURL  "https://www.clarin.eu/faq-page/275
-}
-
-<eden://harvester/re3data/https://dans.knaw.nl/nl/life-sciences/> ;
-  ex:nodeType dcat:Catalog ;
-  ex:usesProperty dct:conformsTo ;
-  ex:usesProperty dct:contactPoint ;
-  ex:usesProperty dct:publisher ;
-  ex:usesProperty dcat:service ;
-.
-
-ex:typeProfile_CatalogRecord a ex:TypeProfile ;
-  ex:inGraph <https://www.clarin.eu/faq-page/275
-            a                 dcat:DataService;
-            dct:conformsTo    "http://www.openarchives.org/OAI/2.0/";
-            dct:title         "OAI-PMH API";
-            dcat:endpointURL  "https://www.clarin.eu/faq-page/275
-}
-
-<eden://harvester/re3data/https://dans.knaw.nl/nl/life-sciences/> ;
-  ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty prov:wasAssociatedWith ;
-  ex:usesProperty prov:wasGeneratedBy ;
-  ex:usesProperty foaf:primaryTopic ;
-.
-
-ex:typeProfile_Project a ex:TypeProfile ;
-  ex:inGraph <https://www.clarin.eu/faq-page/275
-            a                 dcat:DataService;
-            dct:conformsTo    "http://www.openarchives.org/OAI/2.0/";
-            dct:title         "OAI-PMH API";
-            dcat:endpointURL  "https://www.clarin.eu/faq-page/275
-}
-
-<eden://harvester/re3data/https://dans.knaw.nl/nl/life-sciences/> ;
-  ex:nodeType foaf:Project ;
-  ex:usesProperty dct:conformsTo ;
-  ex:usesProperty dct:contactPoint ;
-  ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:identifier ;
   ex:usesProperty dcat:service ;
 .

--- a/.configs/ingest/graph/schema_analysis_summary.ttl
+++ b/.configs/ingest/graph/schema_analysis_summary.ttl
@@ -1,6 +1,6 @@
 # Consolidated schema summary from: .configs/ingest/graph/registry.trig
 # All named graphs aggregated — unique type → property list
-# Generated: 2026-04-29T11:38:35.100Z
+# Generated: 2026-04-29T12:00:58.789Z
 
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
@@ -17,41 +17,120 @@ ex:summary_ex_DepositionPolicy a ex:TypeSummary ;
   ex:nodeType <ex:DepositionPolicy> ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+.
+
+ex:summary_ex_SustainabilityPolicy a ex:TypeSummary ;
+  ex:nodeType <ex:SustainabilityPolicy> ;
+  ex:usesProperty dct:title ;
+.
+
+ex:summary_citation a ex:TypeSummary ;
+  ex:nodeType <http://localhost:3030/service_registry_store/citation> ;
+  ex:usesProperty dct:title ;
+.
+
+ex:summary_CreativeWork a ex:TypeSummary ;
+  ex:nodeType <http://localhost:3030/service_registry_store/CreativeWork> ;
+  ex:usesProperty dct:title ;
+.
+
+ex:summary_license a ex:TypeSummary ;
+  ex:nodeType <http://localhost:3030/service_registry_store/license> ;
+  ex:usesProperty dct:title ;
 .
 
 ex:summary_Policy a ex:TypeSummary ;
   ex:nodeType dct:Policy ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
+.
+
+ex:summary_Kind a ex:TypeSummary ;
+  ex:nodeType vcard:Kind ;
+  ex:usesProperty vcard:hasEmail ;
+  ex:usesProperty vcard:url ;
 .
 
 ex:summary_Catalog a ex:TypeSummary ;
   ex:nodeType dcat:Catalog ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:language ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
-  ex:usesProperty vcard:url ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
 .
 
 ex:summary_CatalogRecord a ex:TypeSummary ;
   ex:nodeType dcat:CatalogRecord ;
-  ex:usesProperty dct:conformsTo ;
-  ex:usesProperty dct:contactPoint ;
-  ex:usesProperty dct:publisher ;
-  ex:usesProperty dcat:service ;
+  ex:usesProperty dct:issued ;
   ex:usesProperty prov:wasAssociatedWith ;
   ex:usesProperty prov:wasGeneratedBy ;
-  ex:usesProperty foaf:homepage ;
   ex:usesProperty foaf:primaryTopic ;
+.
+
+ex:summary_DataService a ex:TypeSummary ;
+  ex:nodeType dcat:DataService ;
+  ex:usesProperty dct:conformsTo ;
+  ex:usesProperty dct:format ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dcat:endpointURL ;
+.
+
+ex:summary_Activity a ex:TypeSummary ;
+  ex:nodeType prov:Activity ;
+  ex:usesProperty prov:name ;
+  ex:usesProperty prov:startedAtTime ;
+.
+
+ex:summary_SoftwareAgent a ex:TypeSummary ;
+  ex:nodeType prov:SoftwareAgent ;
+  ex:usesProperty prov:label ;
+.
+
+ex:summary_Agent a ex:TypeSummary ;
+  ex:nodeType foaf:Agent ;
+  ex:usesProperty vcard:country ;
+  ex:usesProperty foaf:homepage ;
+  ex:usesProperty foaf:name ;
 .
 
 ex:summary_Project a ex:TypeSummary ;
   ex:nodeType foaf:Project ;
   ex:usesProperty dct:conformsTo ;
   ex:usesProperty dct:contactPoint ;
+  ex:usesProperty dct:description ;
+  ex:usesProperty dct:identifier ;
+  ex:usesProperty dct:language ;
+  ex:usesProperty dct:license ;
   ex:usesProperty dct:publisher ;
-  ex:usesProperty vcard:url ;
+  ex:usesProperty dct:title ;
+  ex:usesProperty dct:type ;
+  ex:usesProperty dcat:keyword ;
   ex:usesProperty dcat:service ;
+  ex:usesProperty prov:hadPrimarySource ;
+.
+
+ex:summary_premis_PreservationPolicy a ex:TypeSummary ;
+  ex:nodeType <premis:PreservationPolicy> ;
+  ex:usesProperty dct:title ;
 .


### PR DESCRIPTION
## Schema Extraction — .configs/ingest/graph/registry.trig

> Automatically extracted by TRSP Schema Extraction on 2026-04-29.

### Summary
- **Named graphs analysed**: 324
- **Node types found**: 2561
- **Unique property usages**: 8791
- **Unique types (consolidated)**: 15

### Output files
- `.configs/ingest/graph/schema_analysis.ttl` — per-graph detail (TTL)
- `.configs/ingest/graph/schema_analysis_summary.ttl` — consolidated type→property summary (TTL)