### PR TITLE
feat: add draft FAIR / TRUST / CARE / POSI principle vocabularies

### DIFF
--- a/.configs/vocabs/principles/care.ttl
+++ b/.configs/vocabs/principles/care.ttl
@@ -1,0 +1,149 @@
+@prefix care: <https://purl.org/trsp/care/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+care:ConceptScheme a skos:ConceptScheme ;
+  skos:prefLabel "CARE Principles for Indigenous Data Governance"@en ;
+  dct:title "CARE Principles for Indigenous Data Governance"@en ;
+  dct:creator <https://doi.org/10.5334/dsj-2020-043> ;
+  dct:source <https://doi.org/10.5334/dsj-2020-043> ;
+  dct:created "2020-11-04"^^xsd:date ;
+  dct:modified "2026-05-03"^^xsd:date ;
+  owl:versionInfo "0.1" ;
+  dct:rights <https://spdx.org/licenses/CC-BY-4.0> ;
+  skos:definition "The CARE Principles for Indigenous Data Governance assert that data ecosystems must reflect Collective Benefit, Authority to Control, Responsibility, and Ethics to realise Indigenous data sovereignty."@en .
+
+care:collectiveBenefit a skos:Concept ;
+  skos:prefLabel "Collective Benefit"@en ;
+  skos:notation "C" ;
+  skos:altLabel "C — Collective Benefit"@en ;
+  skos:definition "Data ecosystems shall be designed and function in ways that enable Indigenous Peoples to derive benefit from the data."@en ;
+  skos:narrower care:C1, care:C2, care:C3 ;
+  dct:source <https://doi.org/10.5334/dsj-2020-043> ;
+  skos:inScheme care:ConceptScheme .
+
+care:C1 a skos:Concept ;
+  skos:prefLabel "C1: For inclusive development and innovation"@en ;
+  skos:notation "C1" ;
+  skos:definition "Governments and institutions must actively support the use and reuse of data by and for Indigenous nations and communities by enabling the creation of the foundations for Indigenous innovation, value generation, and the promotion of local self-determined development processes."@en ;
+  skos:broader care:collectiveBenefit ;
+  dct:source <https://doi.org/10.5334/dsj-2020-043> ;
+  skos:inScheme care:ConceptScheme .
+
+care:C2 a skos:Concept ;
+  skos:prefLabel "C2: For improved governance and citizen engagement"@en ;
+  skos:notation "C2" ;
+  skos:definition "Data enrich the planning, implementation, and evaluation processes that support the service and policy needs of Indigenous communities. Data also enable better engagement between citizens, institutions, and governments to improve decision-making."@en ;
+  skos:broader care:collectiveBenefit ;
+  dct:source <https://doi.org/10.5334/dsj-2020-043> ;
+  skos:inScheme care:ConceptScheme .
+
+care:C3 a skos:Concept ;
+  skos:prefLabel "C3: For equitable outcomes"@en ;
+  skos:notation "C3" ;
+  skos:definition "Indigenous data are grounded in community values, which extend to society at large. Any value created from Indigenous data should benefit Indigenous communities in an equitable manner and contribute to Indigenous aspirations for wellbeing."@en ;
+  skos:broader care:collectiveBenefit ;
+  dct:source <https://doi.org/10.5334/dsj-2020-043> ;
+  skos:inScheme care:ConceptScheme .
+
+care:authorityToControl a skos:Concept ;
+  skos:prefLabel "Authority to Control"@en ;
+  skos:notation "A" ;
+  skos:altLabel "A — Authority to Control"@en ;
+  skos:definition "Indigenous Peoples' rights and interests in Indigenous data must be recognised and their authority to control such data be empowered."@en ;
+  skos:narrower care:A1, care:A2, care:A3 ;
+  dct:source <https://doi.org/10.5334/dsj-2020-043> ;
+  skos:inScheme care:ConceptScheme .
+
+care:A1 a skos:Concept ;
+  skos:prefLabel "A1: Recognising rights and interests"@en ;
+  skos:notation "A1" ;
+  skos:definition "Indigenous Peoples have rights and interests in both Traditional Knowledge and Indigenous data. Indigenous Peoples have collective and individual rights to free, prior, and informed consent in the collection and use of such data, including the development of data policies and protocols for collection."@en ;
+  skos:broader care:authorityToControl ;
+  dct:source <https://doi.org/10.5334/dsj-2020-043> ;
+  skos:inScheme care:ConceptScheme .
+
+care:A2 a skos:Concept ;
+  skos:prefLabel "A2: Data for governance"@en ;
+  skos:notation "A2" ;
+  skos:definition "Indigenous Peoples have the right to data that are relevant to their world views and empower self-determination and effective self-governance. Indigenous data must be made available and accessible to Indigenous nations and communities in order to support Indigenous governance."@en ;
+  skos:broader care:authorityToControl ;
+  dct:source <https://doi.org/10.5334/dsj-2020-043> ;
+  skos:inScheme care:ConceptScheme .
+
+care:A3 a skos:Concept ;
+  skos:prefLabel "A3: Governance of data"@en ;
+  skos:notation "A3" ;
+  skos:definition "Indigenous Peoples have the right to develop cultural governance protocols for Indigenous data and be active leaders in the stewardship of, and access to, Indigenous data especially in the context of Indigenous Knowledge."@en ;
+  skos:broader care:authorityToControl ;
+  dct:source <https://doi.org/10.5334/dsj-2020-043> ;
+  skos:inScheme care:ConceptScheme .
+
+care:responsibility a skos:Concept ;
+  skos:prefLabel "Responsibility"@en ;
+  skos:notation "R" ;
+  skos:altLabel "R — Responsibility"@en ;
+  skos:definition "Those working with Indigenous data have a responsibility to share how those data are used to support Indigenous Peoples' self-determination and collective benefit."@en ;
+  skos:narrower care:R1, care:R2, care:R3 ;
+  dct:source <https://doi.org/10.5334/dsj-2020-043> ;
+  skos:inScheme care:ConceptScheme .
+
+care:R1 a skos:Concept ;
+  skos:prefLabel "R1: For positive relationships"@en ;
+  skos:notation "R1" ;
+  skos:definition "Indigenous data use is unviable unless it is linked to relationships built on respect, reciprocity, trust, and mutual understanding, as defined by the Indigenous Peoples to whom those data relate."@en ;
+  skos:broader care:responsibility ;
+  dct:source <https://doi.org/10.5334/dsj-2020-043> ;
+  skos:inScheme care:ConceptScheme .
+
+care:R2 a skos:Concept ;
+  skos:prefLabel "R2: For expanding capability and capacity"@en ;
+  skos:notation "R2" ;
+  skos:definition "Use of Indigenous data invokes a reciprocal responsibility to enhance data literacy within Indigenous communities and to support the development of an Indigenous data workforce and digital infrastructure to enable the creation, collection, management, security, governance, and application of data."@en ;
+  skos:broader care:responsibility ;
+  dct:source <https://doi.org/10.5334/dsj-2020-043> ;
+  skos:inScheme care:ConceptScheme .
+
+care:R3 a skos:Concept ;
+  skos:prefLabel "R3: For Indigenous languages and worldviews"@en ;
+  skos:notation "R3" ;
+  skos:definition "Resources must be provided to generate data grounded in the languages, worldviews, and lived experiences (including values and principles) of Indigenous Peoples."@en ;
+  skos:broader care:responsibility ;
+  dct:source <https://doi.org/10.5334/dsj-2020-043> ;
+  skos:inScheme care:ConceptScheme .
+
+care:ethics a skos:Concept ;
+  skos:prefLabel "Ethics"@en ;
+  skos:notation "E" ;
+  skos:altLabel "E — Ethics"@en ;
+  skos:definition "Indigenous Peoples' rights and wellbeing should be the primary concern at all stages of the data life cycle and across the data ecosystem."@en ;
+  skos:narrower care:E1, care:E2, care:E3 ;
+  dct:source <https://doi.org/10.5334/dsj-2020-043> ;
+  skos:inScheme care:ConceptScheme .
+
+care:E1 a skos:Concept ;
+  skos:prefLabel "E1: For minimising harm and maximising benefit"@en ;
+  skos:notation "E1" ;
+  skos:definition "Ethical data are data that do not stigmatise or portray Indigenous Peoples, cultures, or knowledges in terms of deficit. Ethical data are collected and used in ways that align with Indigenous ethical frameworks and with rights affirmed in UNDRIP."@en ;
+  skos:broader care:ethics ;
+  dct:source <https://doi.org/10.5334/dsj-2020-043> ;
+  skos:inScheme care:ConceptScheme .
+
+care:E2 a skos:Concept ;
+  skos:prefLabel "E2: For justice"@en ;
+  skos:notation "E2" ;
+  skos:definition "Ethical processes address imbalances in power, resources, and how these affect the expression of Indigenous rights and human rights. Ethical allocation of resources recognises and redresses the historical inequity in how knowledge about Indigenous Peoples has been generated and used to the detriment of Indigenous Peoples."@en ;
+  skos:broader care:ethics ;
+  dct:source <https://doi.org/10.5334/dsj-2020-043> ;
+  skos:inScheme care:ConceptScheme .
+
+care:E3 a skos:Concept ;
+  skos:prefLabel "E3: For future use"@en ;
+  skos:notation "E3" ;
+  skos:definition "Data governance should take into account the potential future use and future harm that may come from the reuse of the data. Communities should be the ones to determine what represents acceptable uses of their data, and who makes those decisions."@en ;
+  skos:broader care:ethics ;
+  dct:source <https://doi.org/10.5334/dsj-2020-043> ;
+  skos:inScheme care:ConceptScheme .

--- a/.configs/vocabs/principles/fair.ttl
+++ b/.configs/vocabs/principles/fair.ttl
@@ -1,0 +1,218 @@
+@prefix fair: <https://w3id.org/fair/principles/terms/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+fair:ConceptScheme a skos:ConceptScheme ;
+  skos:prefLabel "FAIR Guiding Principles"@en ;
+  dct:title "FAIR Guiding Principles for scientific data management and stewardship"@en ;
+  dct:creator <https://orcid.org/0000-0001-6818-334X> ;
+  dct:source <https://doi.org/10.1038/sdata.2016.18> ;
+  dct:created "2016-01-01"^^xsd:date ;
+  dct:modified "2026-05-03"^^xsd:date ;
+  owl:versionInfo "0.1" ;
+  dct:rights <https://spdx.org/licenses/CC0-1.0> ;
+  skos:definition "The FAIR Guiding Principles assert that scientific data management and stewardship should make data Findable, Accessible, Interoperable, and Reusable for both humans and machines."@en .
+
+# ── Top-level principles ──────────────────────────────────────────────────────
+
+fair:F a skos:Concept ;
+  skos:prefLabel "Findable"@en ;
+  skos:notation "F" ;
+  skos:definition "The first step in (re)using data is to find them. Metadata and data should be easy to find for both humans and computers."@en ;
+  skos:exactMatch <https://w3id.org/fair/principles/terms/F> ;
+  rdfs:seeAlso <https://w3id.org/fair/principles/terms/F> ;
+  dct:source <https://doi.org/10.1038/sdata.2016.18> ;
+  skos:inScheme fair:ConceptScheme .
+
+fair:A a skos:Concept ;
+  skos:prefLabel "Accessible"@en ;
+  skos:notation "A" ;
+  skos:definition "Once the user finds the required data, they need to know how they can be accessed, possibly including authentication and authorisation."@en ;
+  skos:exactMatch <https://w3id.org/fair/principles/terms/A> ;
+  rdfs:seeAlso <https://w3id.org/fair/principles/terms/A> ;
+  dct:source <https://doi.org/10.1038/sdata.2016.18> ;
+  skos:inScheme fair:ConceptScheme .
+
+fair:I a skos:Concept ;
+  skos:prefLabel "Interoperable"@en ;
+  skos:notation "I" ;
+  skos:definition "The data usually need to be integrated with other data and interoperate with applications or workflows for analysis, storage, and processing."@en ;
+  skos:exactMatch <https://w3id.org/fair/principles/terms/I> ;
+  rdfs:seeAlso <https://w3id.org/fair/principles/terms/I> ;
+  dct:source <https://doi.org/10.1038/sdata.2016.18> ;
+  skos:inScheme fair:ConceptScheme .
+
+fair:R a skos:Concept ;
+  skos:prefLabel "Reusable"@en ;
+  skos:notation "R" ;
+  skos:definition "The ultimate goal of FAIR is to optimise the reuse of data. To achieve this, metadata and data should be well-described so that they can be replicated and/or combined in different settings."@en ;
+  skos:exactMatch <https://w3id.org/fair/principles/terms/R> ;
+  rdfs:seeAlso <https://w3id.org/fair/principles/terms/R> ;
+  dct:source <https://doi.org/10.1038/sdata.2016.18> ;
+  skos:inScheme fair:ConceptScheme .
+
+# ── Findable sub-principles ───────────────────────────────────────────────────
+
+fair:F1 a skos:Concept ;
+  skos:prefLabel "F1: Globally unique and persistent identifier"@en ;
+  skos:notation "F1" ;
+  skos:definition "(Meta)data are assigned a globally unique and persistent identifier."@en ;
+  skos:exactMatch <https://w3id.org/fair/principles/terms/F1> ;
+  rdfs:seeAlso <https://w3id.org/fair/principles/terms/F1> ;
+  skos:broader fair:F ;
+  dct:source <https://doi.org/10.1038/sdata.2016.18> ;
+  skos:inScheme fair:ConceptScheme .
+
+fair:F2 a skos:Concept ;
+  skos:prefLabel "F2: Rich metadata"@en ;
+  skos:notation "F2" ;
+  skos:definition "Data are described with rich metadata (defined by R1 below)."@en ;
+  skos:exactMatch <https://w3id.org/fair/principles/terms/F2> ;
+  rdfs:seeAlso <https://w3id.org/fair/principles/terms/F2> ;
+  skos:broader fair:F ;
+  dct:source <https://doi.org/10.1038/sdata.2016.18> ;
+  skos:inScheme fair:ConceptScheme .
+
+fair:F3 a skos:Concept ;
+  skos:prefLabel "F3: Metadata includes data identifier"@en ;
+  skos:notation "F3" ;
+  skos:definition "Metadata clearly and explicitly include the identifier of the data they describe."@en ;
+  skos:exactMatch <https://w3id.org/fair/principles/terms/F3> ;
+  rdfs:seeAlso <https://w3id.org/fair/principles/terms/F3> ;
+  skos:broader fair:F ;
+  dct:source <https://doi.org/10.1038/sdata.2016.18> ;
+  skos:inScheme fair:ConceptScheme .
+
+fair:F4 a skos:Concept ;
+  skos:prefLabel "F4: Registered or indexed in searchable resource"@en ;
+  skos:notation "F4" ;
+  skos:definition "(Meta)data are registered or indexed in a searchable resource."@en ;
+  skos:exactMatch <https://w3id.org/fair/principles/terms/F4> ;
+  rdfs:seeAlso <https://w3id.org/fair/principles/terms/F4> ;
+  skos:broader fair:F ;
+  dct:source <https://doi.org/10.1038/sdata.2016.18> ;
+  skos:inScheme fair:ConceptScheme .
+
+# ── Accessible sub-principles ─────────────────────────────────────────────────
+
+fair:A1 a skos:Concept ;
+  skos:prefLabel "A1: Retrievable by identifier via standard protocol"@en ;
+  skos:notation "A1" ;
+  skos:definition "(Meta)data are retrievable by their identifier using a standardised communications protocol."@en ;
+  skos:exactMatch <https://w3id.org/fair/principles/terms/A1> ;
+  rdfs:seeAlso <https://w3id.org/fair/principles/terms/A1> ;
+  skos:broader fair:A ;
+  dct:source <https://doi.org/10.1038/sdata.2016.18> ;
+  skos:inScheme fair:ConceptScheme .
+
+fair:A1_1 a skos:Concept ;
+  skos:prefLabel "A1.1: Protocol is open, free, and universally implementable"@en ;
+  skos:notation "A1.1" ;
+  skos:altLabel "A1.1"@en ;
+  skos:definition "The protocol is open, free, and universally implementable."@en ;
+  skos:exactMatch <https://w3id.org/fair/principles/terms/A1.1> ;
+  rdfs:seeAlso <https://w3id.org/fair/principles/terms/A1.1> ;
+  skos:broader fair:A1 ;
+  dct:source <https://doi.org/10.1038/sdata.2016.18> ;
+  skos:inScheme fair:ConceptScheme .
+
+fair:A1_2 a skos:Concept ;
+  skos:prefLabel "A1.2: Protocol allows authentication and authorisation"@en ;
+  skos:notation "A1.2" ;
+  skos:altLabel "A1.2"@en ;
+  skos:definition "The protocol allows for an authentication and authorisation procedure, where necessary."@en ;
+  skos:exactMatch <https://w3id.org/fair/principles/terms/A1.2> ;
+  rdfs:seeAlso <https://w3id.org/fair/principles/terms/A1.2> ;
+  skos:broader fair:A1 ;
+  dct:source <https://doi.org/10.1038/sdata.2016.18> ;
+  skos:inScheme fair:ConceptScheme .
+
+fair:A2 a skos:Concept ;
+  skos:prefLabel "A2: Metadata accessible even when data are unavailable"@en ;
+  skos:notation "A2" ;
+  skos:definition "Metadata are accessible, even when the data are no longer available."@en ;
+  skos:exactMatch <https://w3id.org/fair/principles/terms/A2> ;
+  rdfs:seeAlso <https://w3id.org/fair/principles/terms/A2> ;
+  skos:broader fair:A ;
+  dct:source <https://doi.org/10.1038/sdata.2016.18> ;
+  skos:inScheme fair:ConceptScheme .
+
+# ── Interoperable sub-principles ──────────────────────────────────────────────
+
+fair:I1 a skos:Concept ;
+  skos:prefLabel "I1: Formal, accessible, broadly applicable language for knowledge representation"@en ;
+  skos:notation "I1" ;
+  skos:definition "(Meta)data use a formal, accessible, shared, and broadly applicable language for knowledge representation."@en ;
+  skos:exactMatch <https://w3id.org/fair/principles/terms/I1> ;
+  rdfs:seeAlso <https://w3id.org/fair/principles/terms/I1> ;
+  skos:broader fair:I ;
+  dct:source <https://doi.org/10.1038/sdata.2016.18> ;
+  skos:inScheme fair:ConceptScheme .
+
+fair:I2 a skos:Concept ;
+  skos:prefLabel "I2: Vocabularies that follow FAIR principles"@en ;
+  skos:notation "I2" ;
+  skos:definition "(Meta)data use vocabularies that follow FAIR principles."@en ;
+  skos:exactMatch <https://w3id.org/fair/principles/terms/I2> ;
+  rdfs:seeAlso <https://w3id.org/fair/principles/terms/I2> ;
+  skos:broader fair:I ;
+  dct:source <https://doi.org/10.1038/sdata.2016.18> ;
+  skos:inScheme fair:ConceptScheme .
+
+fair:I3 a skos:Concept ;
+  skos:prefLabel "I3: Qualified references to other (meta)data"@en ;
+  skos:notation "I3" ;
+  skos:definition "(Meta)data include qualified references to other (meta)data."@en ;
+  skos:exactMatch <https://w3id.org/fair/principles/terms/I3> ;
+  rdfs:seeAlso <https://w3id.org/fair/principles/terms/I3> ;
+  skos:broader fair:I ;
+  dct:source <https://doi.org/10.1038/sdata.2016.18> ;
+  skos:inScheme fair:ConceptScheme .
+
+# ── Reusable sub-principles ───────────────────────────────────────────────────
+
+fair:R1 a skos:Concept ;
+  skos:prefLabel "R1: Richly described with accurate and relevant attributes"@en ;
+  skos:notation "R1" ;
+  skos:definition "(Meta)data are richly described with a plurality of accurate and relevant attributes."@en ;
+  skos:exactMatch <https://w3id.org/fair/principles/terms/R1> ;
+  rdfs:seeAlso <https://w3id.org/fair/principles/terms/R1> ;
+  skos:broader fair:R ;
+  dct:source <https://doi.org/10.1038/sdata.2016.18> ;
+  skos:inScheme fair:ConceptScheme .
+
+fair:R1_1 a skos:Concept ;
+  skos:prefLabel "R1.1: Released with clear and accessible usage license"@en ;
+  skos:notation "R1.1" ;
+  skos:altLabel "R1.1"@en ;
+  skos:definition "(Meta)data are released with a clear and accessible data usage license."@en ;
+  skos:exactMatch <https://w3id.org/fair/principles/terms/R1.1> ;
+  rdfs:seeAlso <https://w3id.org/fair/principles/terms/R1.1> ;
+  skos:broader fair:R1 ;
+  dct:source <https://doi.org/10.1038/sdata.2016.18> ;
+  skos:inScheme fair:ConceptScheme .
+
+fair:R1_2 a skos:Concept ;
+  skos:prefLabel "R1.2: Associated with detailed provenance"@en ;
+  skos:notation "R1.2" ;
+  skos:altLabel "R1.2"@en ;
+  skos:definition "(Meta)data are associated with detailed provenance."@en ;
+  skos:exactMatch <https://w3id.org/fair/principles/terms/R1.2> ;
+  rdfs:seeAlso <https://w3id.org/fair/principles/terms/R1.2> ;
+  skos:broader fair:R1 ;
+  dct:source <https://doi.org/10.1038/sdata.2016.18> ;
+  skos:inScheme fair:ConceptScheme .
+
+fair:R1_3 a skos:Concept ;
+  skos:prefLabel "R1.3: Meet domain-relevant community standards"@en ;
+  skos:notation "R1.3" ;
+  skos:altLabel "R1.3"@en ;
+  skos:definition "(Meta)data meet domain-relevant community standards."@en ;
+  skos:exactMatch <https://w3id.org/fair/principles/terms/R1.3> ;
+  rdfs:seeAlso <https://w3id.org/fair/principles/terms/R1.3> ;
+  skos:broader fair:R1 ;
+  dct:source <https://doi.org/10.1038/sdata.2016.18> ;
+  skos:inScheme fair:ConceptScheme .

--- a/.configs/vocabs/principles/posi.ttl
+++ b/.configs/vocabs/principles/posi.ttl
@@ -1,0 +1,210 @@
+@prefix posi: <https://purl.org/trsp/posi/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+posi:ConceptScheme a skos:ConceptScheme ;
+  skos:prefLabel "Principles of Open Scholarly Infrastructure (POSI)"@en ;
+  dct:title "Principles of Open Scholarly Infrastructure (POSI)"@en ;
+  dct:creator <https://openscholarlyinfrastructure.org/> ;
+  dct:source <https://doi.org/10.14454/G8WV-VM65> ;
+  dct:created "2015-01-01"^^xsd:date ;
+  dct:modified "2026-05-03"^^xsd:date ;
+  owl:versionInfo "0.1" ;
+  skos:note "Based on POSI version 2.0, released October 2025."@en ;
+  dct:rights <https://spdx.org/licenses/CC0-1.0> ;
+  skos:definition "The Principles of Open Scholarly Infrastructure (POSI) set out the levers — Governance, Sustainability, and Insurance — that open scholarly infrastructure organisations must act on to earn and retain community trust."@en .
+
+# ── Top-level categories ──────────────────────────────────────────────────────
+
+posi:governance a skos:Concept ;
+  skos:prefLabel "Governance"@en ;
+  skos:notation "G" ;
+  skos:definition "Principles governing how open scholarly infrastructure organisations are structured, run, and held accountable to the communities they serve."@en ;
+  skos:narrower posi:G1, posi:G2, posi:G3, posi:G4, posi:G5, posi:G6, posi:G7 ;
+  dct:source <https://doi.org/10.14454/G8WV-VM65> ;
+  skos:inScheme posi:ConceptScheme .
+
+posi:sustainability a skos:Concept ;
+  skos:prefLabel "Sustainability"@en ;
+  skos:notation "S" ;
+  skos:definition "Principles governing the long-term financial and operational viability of open scholarly infrastructure."@en ;
+  skos:narrower posi:S1, posi:S2, posi:S3, posi:S4, posi:S5, posi:S6, posi:S7, posi:S8 ;
+  dct:source <https://doi.org/10.14454/G8WV-VM65> ;
+  skos:inScheme posi:ConceptScheme .
+
+posi:insurance a skos:Concept ;
+  skos:prefLabel "Insurance"@en ;
+  skos:notation "I" ;
+  skos:definition "Principles that ensure open scholarly infrastructure remains open, accessible, and transferable regardless of what happens to any individual organisation."@en ;
+  skos:narrower posi:I1, posi:I2, posi:I3, posi:I4, posi:I5 ;
+  dct:source <https://doi.org/10.14454/G8WV-VM65> ;
+  skos:inScheme posi:ConceptScheme .
+
+# ── Governance principles ─────────────────────────────────────────────────────
+
+posi:G1 a skos:Concept ;
+  skos:prefLabel "G1: Coverage across the scholarly enterprise"@en ;
+  skos:notation "G1" ;
+  skos:definition "Research transcends disciplines, geography, institutions, and stakeholders. Organisations and the infrastructure they run need to reflect this."@en ;
+  skos:broader posi:governance ;
+  dct:source <https://doi.org/10.14454/G8WV-VM65> ;
+  skos:inScheme posi:ConceptScheme .
+
+posi:G2 a skos:Concept ;
+  skos:prefLabel "G2: Stakeholder governed"@en ;
+  skos:notation "G2" ;
+  skos:definition "A board-governed organisation drawn from the stakeholder community builds confidence that the organisation will make decisions driven by community consensus and a balance of interests."@en ;
+  skos:broader posi:governance ;
+  dct:source <https://doi.org/10.14454/G8WV-VM65> ;
+  skos:inScheme posi:ConceptScheme .
+
+posi:G3 a skos:Concept ;
+  skos:prefLabel "G3: Non-discriminatory participation or membership"@en ;
+  skos:notation "G3" ;
+  skos:definition "An opt-in approach with principles of non-discrimination and inclusivity, where any relevant group may express an interest and should be welcome. Representation in governance must reflect the character of the community or membership."@en ;
+  skos:broader posi:governance ;
+  dct:source <https://doi.org/10.14454/G8WV-VM65> ;
+  skos:inScheme posi:ConceptScheme .
+
+posi:G4 a skos:Concept ;
+  skos:prefLabel "G4: Transparent governance"@en ;
+  skos:notation "G4" ;
+  skos:definition "To foster trust, the processes and policies for governing the organisation and selecting representatives to governance groups should be transparent (within the constraints of privacy laws)."@en ;
+  skos:broader posi:governance ;
+  dct:source <https://doi.org/10.14454/G8WV-VM65> ;
+  skos:inScheme posi:ConceptScheme .
+
+posi:G5 a skos:Concept ;
+  skos:prefLabel "G5: Cannot lobby"@en ;
+  skos:notation "G5" ;
+  skos:definition "Infrastructure organisations should not lobby for regulatory change to cement their own positions or narrow self-interest. However, an infrastructure organisation's role is to support its community, and this can include advocating for policy changes."@en ;
+  skos:broader posi:governance ;
+  dct:source <https://doi.org/10.14454/G8WV-VM65> ;
+  skos:inScheme posi:ConceptScheme .
+
+posi:G6 a skos:Concept ;
+  skos:prefLabel "G6: Living will"@en ;
+  skos:notation "G6" ;
+  skos:definition "Organisations should establish and communicate clear commitments regarding their long-term stewardship responsibilities, including the principles by which assets, data, resources, services, and staff would be responsibly transferred to a successor or the organisation wound down."@en ;
+  skos:broader posi:governance ;
+  dct:source <https://doi.org/10.14454/G8WV-VM65> ;
+  skos:inScheme posi:ConceptScheme .
+
+posi:G7 a skos:Concept ;
+  skos:prefLabel "G7: Regular review of purpose and community value"@en ;
+  skos:notation "G7" ;
+  skos:definition "Organisations and services should regularly review their relevance, effectiveness, and the level of community support to determine whether their continued operation is necessary. If no longer needed, they should take responsible steps to transition or wind down operations."@en ;
+  skos:broader posi:governance ;
+  dct:source <https://doi.org/10.14454/G8WV-VM65> ;
+  skos:inScheme posi:ConceptScheme .
+
+# ── Sustainability principles ─────────────────────────────────────────────────
+
+posi:S1 a skos:Concept ;
+  skos:prefLabel "S1: Transparent operations"@en ;
+  skos:notation "S1" ;
+  skos:definition "To enable organisational accountability and openness, the operating policies and procedures, detailed financials, sustainability models, fees, strategic and product roadmaps, organisational charts, and other appropriate operational information should be made openly available."@en ;
+  skos:broader posi:sustainability ;
+  dct:source <https://doi.org/10.14454/G8WV-VM65> ;
+  skos:inScheme posi:ConceptScheme .
+
+posi:S2 a skos:Concept ;
+  skos:prefLabel "S2: Time-limited funds for time-limited activities only"@en ;
+  skos:notation "S2" ;
+  skos:definition "Operations should be supported by sustainable revenue sources, whereas time-limited funds are used only for time-limited activities. Depending on grants to fund ongoing operations fully makes organisations fragile."@en ;
+  skos:broader posi:sustainability ;
+  dct:source <https://doi.org/10.14454/G8WV-VM65> ;
+  skos:inScheme posi:ConceptScheme .
+
+posi:S3 a skos:Concept ;
+  skos:prefLabel "S3: Goal to generate surplus"@en ;
+  skos:notation "S3" ;
+  skos:definition "It is not enough to merely survive; organisations and services have to be able to adapt and change. Organisations need financial resources beyond immediate operating costs to weather economic, social and technological volatility."@en ;
+  skos:broader posi:sustainability ;
+  dct:source <https://doi.org/10.14454/G8WV-VM65> ;
+  skos:inScheme posi:ConceptScheme .
+
+posi:S4 a skos:Concept ;
+  skos:prefLabel "S4: Establish and maintain financial reserves guided by policy"@en ;
+  skos:notation "S4" ;
+  skos:definition "Organisations should have a clear policy on maintaining financial reserves, including the purpose, minimum and maximum level, and governance of these funds, to support Living Will implementation and response to major unforeseen events."@en ;
+  skos:broader posi:sustainability ;
+  dct:source <https://doi.org/10.14454/G8WV-VM65> ;
+  skos:inScheme posi:ConceptScheme .
+
+posi:S5 a skos:Concept ;
+  skos:prefLabel "S5: Mission-consistent revenue generation"@en ;
+  skos:notation "S5" ;
+  skos:definition "Revenue sources should be evaluated against the infrastructure's mission and not run counter to the aims of the organisation or service."@en ;
+  skos:broader posi:sustainability ;
+  dct:source <https://doi.org/10.14454/G8WV-VM65> ;
+  skos:inScheme posi:ConceptScheme .
+
+posi:S6 a skos:Concept ;
+  skos:prefLabel "S6: Revenue generated from services, not data"@en ;
+  skos:notation "S6" ;
+  skos:definition "Data related to the running of the scholarly infrastructure should be community property. Appropriate revenue sources include value-added services, consulting, API Service Level Agreements, or membership fees."@en ;
+  skos:broader posi:sustainability ;
+  dct:source <https://doi.org/10.14454/G8WV-VM65> ;
+  skos:inScheme posi:ConceptScheme .
+
+posi:S7 a skos:Concept ;
+  skos:prefLabel "S7: Volunteer labour"@en ;
+  skos:notation "S7" ;
+  skos:definition "Organisations that rely on volunteers and their labour should recognise this as a valuable resource for the organisation's long-term viability, and factor it into sustainability planning and risk management."@en ;
+  skos:broader posi:sustainability ;
+  dct:source <https://doi.org/10.14454/G8WV-VM65> ;
+  skos:inScheme posi:ConceptScheme .
+
+posi:S8 a skos:Concept ;
+  skos:prefLabel "S8: Transition planning"@en ;
+  skos:notation "S8" ;
+  skos:definition "Organisations that are heavily dependent on a limited number of individuals should take steps to reduce their dependence, including via transition and succession planning, so that the organisation is not at risk of collapse in the event of their departure."@en ;
+  skos:broader posi:sustainability ;
+  dct:source <https://doi.org/10.14454/G8WV-VM65> ;
+  skos:inScheme posi:ConceptScheme .
+
+# ── Insurance principles ──────────────────────────────────────────────────────
+
+posi:I1 a skos:Concept ;
+  skos:prefLabel "I1: Open source"@en ;
+  skos:notation "I1" ;
+  skos:definition "All software and non-physical assets required to run the infrastructure should be available under an open-source licence."@en ;
+  skos:broader posi:insurance ;
+  dct:source <https://doi.org/10.14454/G8WV-VM65> ;
+  skos:inScheme posi:ConceptScheme .
+
+posi:I2 a skos:Concept ;
+  skos:prefLabel "I2: Ensure open and secure data accessibility"@en ;
+  skos:notation "I2" ;
+  skos:definition "To support potential forking or replication, infrastructure should aim to make all relevant data openly available following best practices such as applying a CC0 waiver where appropriate, balanced with compliance with privacy, data protection, and security requirements."@en ;
+  skos:broader posi:insurance ;
+  dct:source <https://doi.org/10.14454/G8WV-VM65> ;
+  skos:inScheme posi:ConceptScheme .
+
+posi:I3 a skos:Concept ;
+  skos:prefLabel "I3: Available and preserved"@en ;
+  skos:notation "I3" ;
+  skos:definition "It is not enough that content, data, and software be open if there is no practical way to obtain them. These resources should be easily available with clear public documentation, and deposited with at least one trusted third-party digital archive."@en ;
+  skos:broader posi:insurance ;
+  dct:source <https://doi.org/10.14454/G8WV-VM65> ;
+  skos:inScheme posi:ConceptScheme .
+
+posi:I4 a skos:Concept ;
+  skos:prefLabel "I4: Patent non-assertion"@en ;
+  skos:notation "I4" ;
+  skos:definition "The organisation should commit to a patent non-assertion policy or covenant. The organisation may obtain patents to protect its own operations, but not use them to prevent the community from replicating the infrastructure."@en ;
+  skos:broader posi:insurance ;
+  dct:source <https://doi.org/10.14454/G8WV-VM65> ;
+  skos:inScheme posi:ConceptScheme .
+
+posi:I5 a skos:Concept ;
+  skos:prefLabel "I5: Prioritise interoperability and open standards"@en ;
+  skos:notation "I5" ;
+  skos:definition "Infrastructures should adopt and support widely accepted open standards to ensure that systems, data, and services can be replicated, migrated, or integrated with minimal disruption without the use of proprietary extensions or software."@en ;
+  skos:broader posi:insurance ;
+  dct:source <https://doi.org/10.14454/G8WV-VM65> ;
+  skos:inScheme posi:ConceptScheme .

--- a/.configs/vocabs/principles/trust.ttl
+++ b/.configs/vocabs/principles/trust.ttl
@@ -1,0 +1,64 @@
+@prefix trust: <https://purl.org/trsp/trust/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+trust:ConceptScheme a skos:ConceptScheme ;
+  skos:prefLabel "TRUST Principles for Digital Repositories"@en ;
+  dct:title "TRUST Principles for digital repositories"@en ;
+  dct:creator <https://doi.org/10.1038/s41597-020-0486-7> ;
+  dct:source <https://doi.org/10.1038/s41597-020-0486-7> ;
+  dct:created "2020-05-14"^^xsd:date ;
+  dct:modified "2026-05-03"^^xsd:date ;
+  owl:versionInfo "0.1" ;
+  dct:rights <https://spdx.org/licenses/CC0-1.0> ;
+  skos:definition "The TRUST Principles provide a common framework by which digital repositories can demonstrate that they are trustworthy and reliable custodians of digital objects."@en .
+
+trust:transparency a skos:Concept ;
+  skos:prefLabel "Transparency"@en ;
+  skos:notation "T" ;
+  skos:altLabel "T — Transparency"@en ;
+  skos:definition "To be transparent about specific repository services and data holdings that are verifiable by publicly accessible evidence."@en ;
+  skos:exactMatch <https://www.wikidata.org/entity/Q120327866> ;
+  rdfs:seeAlso <https://doi.org/10.1038/s41597-020-0486-7> ;
+  dct:source <https://doi.org/10.1038/s41597-020-0486-7> ;
+  skos:inScheme trust:ConceptScheme .
+
+trust:responsibility a skos:Concept ;
+  skos:prefLabel "Responsibility"@en ;
+  skos:notation "R" ;
+  skos:altLabel "R — Responsibility"@en ;
+  skos:definition "To be responsible for ensuring the authenticity and integrity of data holdings and for the reliability of its service."@en ;
+  skos:exactMatch <https://www.wikidata.org/entity/Q120327867> ;
+  rdfs:seeAlso <https://doi.org/10.1038/s41597-020-0486-7> ;
+  dct:source <https://doi.org/10.1038/s41597-020-0486-7> ;
+  skos:inScheme trust:ConceptScheme .
+
+trust:userFocus a skos:Concept ;
+  skos:prefLabel "User Focus"@en ;
+  skos:notation "U" ;
+  skos:altLabel "U — User Focus"@en ;
+  skos:definition "To ensure that the data management norms and expectations of target user communities are met."@en ;
+  rdfs:seeAlso <https://doi.org/10.1038/s41597-020-0486-7> ;
+  dct:source <https://doi.org/10.1038/s41597-020-0486-7> ;
+  skos:inScheme trust:ConceptScheme .
+
+trust:sustainability a skos:Concept ;
+  skos:prefLabel "Sustainability"@en ;
+  skos:notation "S" ;
+  skos:altLabel "S — Sustainability"@en ;
+  skos:definition "To sustain services and preserve data holdings for the long-term, where such decisions are based on sound business planning."@en ;
+  rdfs:seeAlso <https://doi.org/10.1038/s41597-020-0486-7> ;
+  dct:source <https://doi.org/10.1038/s41597-020-0486-7> ;
+  skos:inScheme trust:ConceptScheme .
+
+trust:technology a skos:Concept ;
+  skos:prefLabel "Technology"@en ;
+  skos:notation "T2" ;
+  skos:altLabel "T — Technology"@en ;
+  skos:definition "To provide infrastructure and capabilities to support secure, persistent, and reliable services."@en ;
+  rdfs:seeAlso <https://doi.org/10.1038/s41597-020-0486-7> ;
+  dct:source <https://doi.org/10.1038/s41597-020-0486-7> ;
+  skos:inScheme trust:ConceptScheme .


### PR DESCRIPTION
Adds four draft SKOS principle vocabulary TTL files to `.configs/vocabs/principles/`:

- **fair.ttl** — FAIR Guiding Principles (Wilkinson et al. 2016), with `skos:exactMatch` to `https://w3id.org/fair/principles/terms/`
- **trust.ttl** — TRUST Principles (Lin et al. 2020)
- **care.ttl** — CARE Principles for Indigenous Data Governance (Carroll et al. 2020)
- **posi.ttl** — Principles of Open Scholarly Infrastructure v2.0 (POSI Adopters 2025)

Each concept has: `skos:prefLabel`, `skos:notation` (compact ID), `skos:definition`, `dct:source` (canonical DOI), and external `skos:exactMatch`/`rdfs:seeAlso` where available.

Generated by TRSP Curation Platform — 2026-05-03T08:57:03.500Z