### PR TITLE
Vocab Linker: append to .configs/vocabs/attr/package-type.ttl

### DIFF
--- a/.configs/vocabs/attr/package-type.ttl
+++ b/.configs/vocabs/attr/package-type.ttl
@@ -11,16 +11,20 @@ trsp:package-type-scheme
   dct:title "Package Encoding Type"@en ;
   dct:created "2026-05-03"^^xsd:date ;
   dct:modified "2026-05-03"^^xsd:date ;
-  owl:versionInfo "0.1" .
+  owl:versionInfo "0.2" .
 
 trsp:bagit
   a skos:Concept ;
   skos:prefLabel "Bag-It"@en ;
+  skos:closeMatch <https://doi.org/10.25504/FAIRsharing.3224a5> ;
+  rdfs:seeAlso <https://doi.org/10.25504/FAIRsharing.3224a5> ;
   skos:inScheme trsp:package-type-scheme .
 
 trsp:rocrate
   a skos:Concept ;
   skos:prefLabel "RO-Crate"@en ;
+  skos:closeMatch <https://doi.org/10.25504/FAIRsharing.wUoZKE> ;
+  rdfs:seeAlso <https://doi.org/10.25504/FAIRsharing.wUoZKE> ;
   skos:inScheme trsp:package-type-scheme .
 
 trsp:aip


### PR DESCRIPTION
Automated vocabulary TTL append via TRSP Curation Platform Vocab Linker.

Mode: Append (new concepts only)
Generated: 2026-05-03T21:10:26.483Z