### PR TITLE
Vocab Linker: append to .configs/vocabs/attr/rights-encoding-type.ttl

### DIFF
--- a/.configs/vocabs/attr/rights-encoding-type.ttl
+++ b/.configs/vocabs/attr/rights-encoding-type.ttl
@@ -10,8 +10,8 @@ trsp:rights-encoding-type-scheme
   skos:prefLabel "Rights Encoding Vocabulary"@en ;
   dct:title "Rights Encoding Vocabulary"@en ;
   dct:created "2026-05-03"^^xsd:date ;
-  dct:modified "2026-05-03"^^xsd:date ;
-  owl:versionInfo "0.1" .
+  dct:modified "2026-05-04"^^xsd:date ;
+  owl:versionInfo "0.2" .
 
 trsp:rel
   a skos:Concept ;
@@ -26,6 +26,8 @@ trsp:ccrel
 trsp:odrl
   a skos:Concept ;
   skos:prefLabel "ODRL"@en ;
+  skos:broadMatch <http://www.w3.org/ns/odrl/2/core> ;
+  rdfs:seeAlso <http://www.w3.org/ns/odrl/2/core> ;
   skos:inScheme trsp:rights-encoding-type-scheme .
 
 trsp:rsl


### PR DESCRIPTION
Automated vocabulary TTL append via TRSP Curation Platform Vocab Linker.

Mode: Append (new concepts only)
Generated: 2026-05-04T05:20:22.564Z