### PR TITLE
Publish API definitions to .trsp/api

### DIFF
--- a/.trsp/api/openapi.json
+++ b/.trsp/api/openapi.json
@@ -7,7 +7,7 @@
   },
   "servers": [
     {
-      "url": "https://your_server_name.org"
+      "url": "https://your_server_url.org"
     }
   ],
   "paths": {


### PR DESCRIPTION
Exported the curated API layer for **TRSP Knowledge Base** to `.trsp/api/`.

- `api-config.json` — deploy bundle (5 endpoints, 34 source files)
- `openapi.json` — OpenAPI 3.1 definition
- `knowledge-base.json` — KB config (secret-free)

Generated: 2026-08-19T11:21:49.487Z