### PR TITLE
Hypothesis annotations: add 140 annotation(s)

### DIFF
--- a/data/source/annotation.ttl
+++ b/data/source/annotation.ttl
@@ -1,0 +1,1826 @@
+@prefix oa: <http://www.w3.org/ns/oa#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+
+<https://hypothes.is/a/_7_QDPQ2EfCHfm85XXLzzQ> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "Metadata aligned with community norms"
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://www.nature.com/articles/s41597-020-0486-7> ;
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact "Repository users should have confidence that data depositors are prompted to provide all metadata compliant with the community norms, as this greatly enhances the discoverability and usefulness of the data. Knowing that a repository verifies the integrity of available data and metadata assures potential users that the data holdings are more likely to be interoperable with other relevant datasets. Both depositors and users must have confidence that the data will remain accessible over time, and thus can be cited and referenced in scholarly publications." ;
+            oa:prefix "\n                \n              " ;
+            oa:suffix "Responsibility may be clarified "
+        ]
+    ]
+    .
+
+<https://hypothes.is/a/_97eKO2IEe2N3y-4h5tLwA> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "{Open Source}"
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://openscholarlyinfrastructure.org/> ;
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact "Open source – All software required to run the infrastructure should be available under an open source license. This does not include other software that may be involved with running the organisation." ;
+            oa:prefix "or membership fees.\n\nInsurance\n\n" ;
+            oa:suffix "\nOpen data (within constraints o"
+        ]
+    ]
+    .
+
+<https://hypothes.is/a/_WK3gKGYEe-QK3N254EDcQ> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics \nIndigenous data use is unviable unless linked to relationships built on respect, reciprocity, trust, and mutual understanding, as defined by the Indigenous Peoples to whom those data relate. Those working with Indigenous data are responsible for ensuring that the creation, interpretation, and use of those data uphold, or are respectful of, the dignity of Indigenous nations and communities."
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://www.gida-global.org/care>
+    ]
+    .
+
+<https://hypothes.is/a/-rtaDKEoEe-WHLsR6HznJA> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics\n\nPolicy that details how the preservation of the data is ensured: does the repository have a page, or document that describes this?"
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://zenodo.org/records/4084763>
+    ]
+    .
+
+<https://hypothes.is/a/-x3zmKEnEe-kG7NXVVKnEg> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics \n\nContact (person or organisation) for the record in FAIRsharing that describes the repository: has the owner or maintainer of the repository claimed the record and vetted its descriptions? Although records in FAIRsharing are curated by its in-house team, the participation of the owner or maintainer of the repository helps verifying the information and tracking the evolution of the resource.\""
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://zenodo.org/records/4084763>
+    ]
+    .
+
+<https://hypothes.is/a/14FIsPQ6EfCQA9PdphFTpQ> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "Funding imperative in respect of financial sustainability"
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://www.nature.com/articles/s41597-020-0486-7> ;
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact "Securing funding to enable ongoing usage and to maintain the desirable properties of the data resources that the repository has been entrusted with preserving and disseminating." ;
+            oa:prefix "             \n                  " ;
+            oa:suffix "\n                \n              "
+        ]
+    ]
+    .
+
+<https://hypothes.is/a/1AmgjKKJEe-_Q2_Pa1V5-Q> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics \nPID Manager MUST ensure that the entity remains linked to the PID. In case that the entity being identified is deleted or ceases to exist, tombstone information needs to be included in the PID attribute set."
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://zenodo.org/records/10067253>
+    ]
+    .
+
+<https://hypothes.is/a/1kbTTKEIEe-XzDsBH0HyKw> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics \n\nThe organization responsible for the data repository"
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://zenodo.org/records/11221855>
+    ]
+    .
+
+<https://hypothes.is/a/1LVRTqGYEe-imsMx2Oww1Q> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics \nIndigenous Peoples have the right to develop cultural governance protocols for Indigenous data and be active leaders in the stewardship of, and access to, Indigenous data especially in the context of Indigenous Knowledge"
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://www.gida-global.org/care>
+    ]
+    .
+
+<https://hypothes.is/a/2bJlEuyOEe2CMd8vxXvZVA> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "{Stakeholder Governed}"
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://openscholarlyinfrastructure.org/> ;
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact "Stakeholder Governed – a board-governed organisation drawn from the stakeholder community builds more confidence that the organisation will take decisions driven by community consensus and consideration of different interests." ;
+            oa:prefix "pports it needs to do the same.\n" ;
+            oa:suffix "\nNon-discriminatory membership –"
+        ]
+    ]
+    .
+
+<https://hypothes.is/a/2fqRVKBZEe-dt3NmNfv8Ww> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics\nThe repository applies documented processes to ensure data and metadata storage and integrity."
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://zenodo.org/records/7051012>
+    ]
+    .
+
+<https://hypothes.is/a/2pWEPPQ9EfCuZr8Bbt_9IA> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "Services MUST be available to all\nresearchers in the EU."
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://zenodo.org/records/8403957>
+    ]
+    .
+
+<https://hypothes.is/a/3QOLkKKIEe-3HXOmuBvMwQ> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics \nA PID Service infrastructure MUST be at a minimum technology readiness level of 8. This applies to basic services (registration, resolution)."
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://zenodo.org/records/10067253>
+    ]
+    .
+
+<https://hypothes.is/a/4_YA2KEKEe-PqEstLEaC0Q> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics \n\nThe terms of reuse of datasets that are provided by a repository"
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://zenodo.org/records/11221855>
+    ]
+    .
+
+<https://hypothes.is/a/4vxQpGXPEe-tDfe0iFxf0Q> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "Part of Confluence\n\n[](https://wiki.lyrasis.org/display/ARKs/ARKs+in+the+Open+Project)"
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://wiki.lyrasis.org/display/ARKs/ARKs+in+the+Open+Project> ;
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact "In 2018 the California Digital Library (CDL) and DuraSpace (now LYRASIS) announced a collaboration aimed at building an open, international community around Archival Resource Keys (ARKs) and their use as persistent identifiers in the open scholarly ecosystem.In January 2021, the community that matured from that collaboration was renamed theARK Alliance (arks.org)," ;
+            oa:prefix "                       \n        " ;
+            oa:suffix "and it became the new public fac"
+        ]
+    ]
+    .
+
+<https://hypothes.is/a/671SzKEJEe-LCFvHhvUSpA> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics\n\nFormat/s of the metadata that describes datasets in a repository"
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://zenodo.org/records/11221855>
+    ]
+    .
+
+<https://hypothes.is/a/69FnSJ85Ee-MbCOsJgfzng> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics\n\nThe repository has adequate funding and sufficient numbers of staff managed through ac lear system of governance to effectively carry out the mission."
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://zenodo.org/records/7051012>
+    ]
+    .
+
+<https://hypothes.is/a/7-Bf2CSREe-kBw_OeDMSRQ> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics"
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://www.nature.com/articles/s41597-020-0486-7> ;
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact "and the security of the system and its content" ;
+            oa:prefix "ensitive information resources, " ;
+            oa:suffix ".\n                \n             "
+        ]
+    ]
+    .
+
+<https://hypothes.is/a/7g3xdKBcEe-XlM_7wro5Dw> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics\nThe repository is managed on well-supported operating systems and other core infrastructural software and hardware appropriate to the services it provides to its Designated Community."
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://zenodo.org/records/7051012>
+    ]
+    .
+
+<https://hypothes.is/a/7xe2hCPgEe-Cr0fvCEpXgg> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics"
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://www.nature.com/articles/s41597-020-0486-7> ;
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact "Continued access to data is dependent upon the ability of the repository to provide services over time, and to respond with new or improved services to meet evolving user community requirements" ;
+            oa:prefix "nt and future user communities. " ;
+            oa:suffix ".A TRUSTworthy repository may de"
+        ]
+    ]
+    .
+
+<https://hypothes.is/a/84KgBiPJEe-aEXvumJj8mQ> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics"
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://www.nature.com/articles/s41597-020-0486-7> ;
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact "repositories should ensure that, at a minimum, the mission statement and scope of the repository are clearly stated" ;
+            oa:prefix " compliant with this principle, " ;
+            oa:suffix ". In addition, the following asp"
+        ]
+    ]
+    .
+
+<https://hypothes.is/a/89_L0KKIEe-YNl8kqG_mfg> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics \nPID Authorities and Services MUST agree to be certified with a mutually agreed frequency in respect of policy compliance."
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://zenodo.org/records/10067253>
+    ]
+    .
+
+<https://hypothes.is/a/8TRzvKGZEe-bK5fdmurkyg> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics \nEthical processes address imbalances in power, resources, and how these affect the expression of Indigenous rights and human rights. Ethical processes must include representation from relevant Indigenous communities"
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://www.gida-global.org/care>
+    ]
+    .
+
+<https://hypothes.is/a/9oEcnPQ9EfC93Sd51p8yIQ> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "Justifiable Cost PID Services SHOULD be provided at justifiable cost to PID Owners and PID Managers within EOSC."
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://zenodo.org/records/8403957>
+    ]
+    .
+
+<https://hypothes.is/a/9PVzyqBPEe-pMzcnjRhWDQ> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP desirable Characteristics"
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://www.nature.com/articles/s41597-020-0486-7> ;
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact "To fulfill this role, TDRs must demonstrate essential and enduring capabilities necessary to enable access and reuse of data over time for the communities they serve" ;
+            oa:prefix "sibilities of data stewardship. " ;
+            oa:suffix ". TDRs support data curation and"
+        ]
+    ]
+    .
+
+<https://hypothes.is/a/a026EO1KEe2VuZ_y6iK2Bg> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "{Time-Limited}"
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://openscholarlyinfrastructure.org/> ;
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact "Time-limited funds are used only for time-limited activities – day to day operations should be supported by day to day sustainable revenue sources. Grant dependency for funding operations makes them fragile and more easily distracted from building core infrastructure." ;
+            oa:prefix "and wind down.\n\nSustainability\n\n" ;
+            oa:suffix "\nGoal to generate surplus – orga"
+        ]
+    ]
+    .
+
+<https://hypothes.is/a/a026EO1KEe2VuZ_y6iK2Bg> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "{Time-Limited}"
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://openscholarlyinfrastructure.org/> ;
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact "Time-limited funds are used only for time-limited activities – day to day operations should be supported by day to day sustainable revenue sources. Grant dependency for funding operations makes them fragile and more easily distracted from building core infrastructure." ;
+            oa:prefix "and wind down.\n\nSustainability\n\n" ;
+            oa:suffix "\nGoal to generate surplus – orga"
+        ]
+    ]
+    .
+
+<https://hypothes.is/a/aBERop9bEe-j-neEY_FU1w> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics\n\nThe repository guarantees the authenticity of the digital objects and provides provenance information."
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://zenodo.org/records/7051012>
+    ]
+    .
+
+<https://hypothes.is/a/AjpvmKELEe-cVsvAIEYRlg> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics \n\nEarning a certification, typically by means of a third party audit or community endorsement process, presents evidence that a repository meets a formal standard and adheres to a set of best, professional practices."
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://zenodo.org/records/11221855>
+    ]
+    .
+
+<https://hypothes.is/a/AzkSXGf4Ee6_qROC8MGoQA> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "Succession"
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://datascience.codata.org/articles/10.5334/dsj-2017-039> ;
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact "succession: The plan for dealing with sudden loss of provider viability, including set-aside funding and length of time that operations would be able to support continued operation while a successor provider is found to keep references intact." ;
+            oa:prefix "ct-level metadata or service.\n\n\n" ;
+            oa:suffix "\n\ncertification: If certified, a"
+        ]
+    ]
+    .
+
+<https://hypothes.is/a/B56FLqKLEe-o_Sso3i5X0g> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics \nPID Service SHOULD resolve at least p percent of PIDs in a randomised sample, where p is determined by community and dependency expectations."
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://zenodo.org/records/10067253>
+    ]
+    .
+
+<https://hypothes.is/a/bUdOqG-uEe6-qFMJDoxH9Q> a oa:Annotation ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <http://www.hyam.net/blog/archives/325> ;
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact "DOIs have a business model. LSIDs currently do not. Without a business model (read funding) we should stick to something that doesn’t have the implementation/adoption impediment of LSIDs and make the best of it (i.e. just have a usage policy for HTTP URIs)." ;
+            oa:prefix "rge organisations and projects.\n" ;
+            oa:suffix "\nThe up coming e-Biosphere confe"
+        ]
+    ]
+    .
+
+<https://hypothes.is/a/by_7PiVIEe-88fv1YjlShQ> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics"
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://zenodo.org/records/7051012>
+    ]
+    .
+
+<https://hypothes.is/a/c-D_fCSIEe-NkcdmSXn5Ig> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics"
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://zenodo.org/records/7051012>
+    ]
+    .
+
+<https://hypothes.is/a/CAL7eKEIEe-9H5OInjOkWQ> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics \nThe name that the repository provides and what users commonly call the repository."
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://zenodo.org/records/11221855>
+    ]
+    .
+
+<https://hypothes.is/a/cBVBzKGYEe-YL-u3WXCqvA> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics \nIndigenous Peoples have rights and interests in both Indigenous Knowledge and Indigenous data. Indigenous Peoples have collective and individual rights to free, prior, and informed consent in the collection and use of such data, including the development of data policies and protocols for collection."
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://www.gida-global.org/care>
+    ]
+    .
+
+<https://hypothes.is/a/cw31YqKJEe-M1XcOBTzBgg> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics \nServices MUST be available to all researchers in the EU."
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://zenodo.org/records/10067253>
+    ]
+    .
+
+<https://hypothes.is/a/d_-EWO2IEe29rVf6X2B7qw> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "{Mission-Consistent}"
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://openscholarlyinfrastructure.org/> ;
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact "Mission-consistent revenue generation – potential revenue sources should be considered for consistency with the organisational mission and not run counter to the aims of the organisation" ;
+            oa:prefix " and investment in development.\n" ;
+            oa:suffix ". For instance…\nRevenue based on"
+        ]
+    ]
+    .
+
+<https://hypothes.is/a/dcYtap9fEe-aPstlb2UCGg> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics\n\nIdentification checks for depositors."
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://zenodo.org/records/7051012>
+    ]
+    .
+
+<https://hypothes.is/a/Dhs6UqKJEe-6gsuypDtbWQ> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics \nPhysical and conceptual entities MUST be represented via a digital representation (e.g. landing page, metadata, attribute set, database index) to have a presence in the digital landscape."
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://zenodo.org/records/10067253>
+    ]
+    .
+
+<https://hypothes.is/a/Di7VcqDQEe-J6UuuQhd2Zw> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics"
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://www.nature.com/articles/s41597-020-0486-7> ;
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact "The adoption of technological capabilities should be completed in conjunction with the organizational, managerial and stewardship capabilities that facilitate the continuing use of a data repository’s holdings" ;
+            oa:prefix "ity of stewarded research data”." ;
+            oa:suffix "10,21. Describing the needs for "
+        ]
+    ]
+    .
+
+<https://hypothes.is/a/DnGtUqGYEe-ZrGu__Z0KZA> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics \nData enrich the planning, implementation, and evaluation processes that support the service and policy needs of Indigenous communities. Data also enable better engagement between citizens, institutions, and governments to improve decision-making. Ethical use of open data has the capacity to improve transparency and decision-making by providing Indigenous nations and communities with a better understanding of their peoples, territories, and resources. It similarly can provide greater insight into third-party policies and programs affecting Indigenous Peoples."
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://www.gida-global.org/care>
+    ]
+    .
+
+<https://hypothes.is/a/DZa8DKBSEe-kZieQ-8gogg> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics\n\nThe repository enables users to discover the digital objects and refer to them in a persistent way through proper citation."
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://zenodo.org/records/7051012>
+    ]
+    .
+
+<https://hypothes.is/a/ehu8kO2fEe2lN0MVwZsoCg> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "{Administrative Capacity}"
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://www.doi.org/the-identifier/resources/handbook/4_data_model> ;
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact "The second aim of DOI data model policy is “to ensure minimum standards of quality of administration of DOI names by Registration Agencies, and facilitate the administration of the DOI system as a whole”." ;
+            oa:prefix "4.2.2 Administrative capability\n" ;
+            oa:suffix " This aim may also be seen as su"
+        ]
+    ]
+    .
+
+<https://hypothes.is/a/ehu8kO2fEe2lN0MVwZsoCg> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "{Administrative Capacity}"
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://www.doi.org/the-identifier/resources/handbook/4_data_model> ;
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact "The second aim of DOI data model policy is “to ensure minimum standards of quality of administration of DOI names by Registration Agencies, and facilitate the administration of the DOI system as a whole”." ;
+            oa:prefix "4.2.2 Administrative capability\n" ;
+            oa:suffix " This aim may also be seen as su"
+        ]
+    ]
+    .
+
+<https://hypothes.is/a/eI_0vqBYEe-RIZ9vnmaiyg> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics\n\nThe repository must obtain all necessary rights from the depositor, and demonstrate that there are sufficient controls in place to ensure they are applied and monitored."
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://zenodo.org/records/7051012>
+    ]
+    .
+
+<https://hypothes.is/a/EIAdNKEJEe-LA4-CfIuMyQ> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics\n\nContact information for the data repository"
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://zenodo.org/records/11221855>
+    ]
+    .
+
+<https://hypothes.is/a/Eih8-iPLEe-711PH1sn90w> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics"
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://zenodo.org/records/7051012>
+    ]
+    .
+
+<https://hypothes.is/a/Eih8-iPLEe-711PH1sn90w> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics"
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://zenodo.org/records/7051012>
+    ]
+    .
+
+<https://hypothes.is/a/emLpgqDKEe-omHP-f7Chzw> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics\n\nThe community-defined standards the repository implements to enable the representation of data and/or metadata in a consistent, machine readable form (e.g. via models, formats, schemas, vocabularies, ontologies). These standards facilitate the discovery and interpretation of data and/or metadata."
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://zenodo.org/records/4084763>
+    ]
+    .
+
+<https://hypothes.is/a/fDOdxqEJEe-Xzbvpf6vAMQ> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics\n\nThe subject classification of datasets in a repository."
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://zenodo.org/records/11221855>
+    ]
+    .
+
+<https://hypothes.is/a/fJNeJKBUEe-XyOuOgrrsLA> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics\n\nThe repository accepts data and metadata based on defined criteria to ensure relevance and understandability for users."
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://zenodo.org/records/7051012>
+    ]
+    .
+
+<https://hypothes.is/a/FRJ8FKEpEe-36_ur5asmEA> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics \n\nLicence or terms of use for reuse of existing data in the repository; these can be the same for every dataset in the repository, or vary from dataset to dataset: what are the conditions under which one can reuse the data?"
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://zenodo.org/records/4084763>
+    ]
+    .
+
+<https://hypothes.is/a/fUO3IKDQEe-5BSOeH-aCaw> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics\n\nThe type of funding (e.g. grants, donations, memberships) and the organisation(s) that fund the repository."
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://zenodo.org/records/4084763>
+    ]
+    .
+
+<https://hypothes.is/a/FvkgyvQ8EfCnKV-O9UUDlA> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "An applicant for CoreTrustSeal must offer a long term preservation service. Some parts of the\ncollection may have lower levels of care but this must be made clear in the text. Once\nassigned each reviewer will briefly check:\n● the definition of the designated community to see whether it is clear enough.\n● the preservation plan to ensure that active preservation is in place.\n● the ingest & appraisal to confirm that digital objects receive active preservation.\n● Reuse to confirm that the outcomes of curation are aligned with the needs of the\ndesignated community."
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://zenodo.org/records/7051012>
+    ]
+    .
+
+<https://hypothes.is/a/FvKu8KGXEe-11YtDBimaSg> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics \nData ecosystems shall be designed and function in ways that enable Indigenous Peoples to derive benefit from the data."
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://www.gida-global.org/care>
+    ]
+    .
+
+<https://hypothes.is/a/gXqDNCSREe-tLSNJKn4zmA> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics"
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://www.nature.com/articles/s41597-020-0486-7> ;
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact "" ;
+            oa:prefix "             \n                  " ;
+            oa:suffix "Managing the intellectual proper"
+        ]
+    ]
+    .
+
+<https://hypothes.is/a/GzzwtqBbEe-QrePwGBZNVg> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics"
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://www.nature.com/articles/s41597-020-0486-7> ;
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact "Implementing relevant data metrics and making these available to users." ;
+            oa:prefix "             \n                  " ;
+            oa:suffix "\n                \n              "
+        ]
+    ]
+    .
+
+<https://hypothes.is/a/hbb2hKGXEe-lHnsJu1hWTQ> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics \nIndigenous Peoples’ rights and wellbeing should be the primary concern."
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://www.gida-global.org/care>
+    ]
+    .
+
+<https://hypothes.is/a/hJKXBCMlEe-8SvNEKgmVSA> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Requirements and Desirable Characteristics"
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://zenodo.org/records/7051012>
+    ]
+    .
+
+<https://hypothes.is/a/HWAsGqKKEe-2mmMoyeyrDA> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics \nThe PID Manager MUST maintain the integrity of the relationship between entities and their PIDs, in conformance to a PID Scheme defined by a PID Authority."
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://zenodo.org/records/10067253>
+    ]
+    .
+
+<https://hypothes.is/a/I-rBoKCZEe-BzEsVgm-zbA> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics\n\nData access mechanisms and terms to define access at repository and/or dataset level: what is the process through which access can be requested (and granted)? For example, is the data is freely available or subject to a request and approval process."
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://zenodo.org/records/4084763>
+    ]
+    .
+
+<https://hypothes.is/a/IDJWeKELEe-RU4Oj0GaxCw> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics \n\nPolicies that explain the repository’s commitment and processes that ensure the long-term preservation, fitness, and availability of datasets."
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://zenodo.org/records/11221855>
+    ]
+    .
+
+<https://hypothes.is/a/IMd6dKKLEe-ZRj9flmH_Cw> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics \nThe PID manager MUST provide the functionality required to maintain PID attributes."
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://zenodo.org/records/10067253>
+    ]
+    .
+
+<https://hypothes.is/a/IniHMqEKEe-wNyMtshldEw> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics\n\nCuratorial services performed by repository functionality or personnel that enhance or otherwise add value to datasets and create purposeful collections of data."
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://zenodo.org/records/11221855>
+    ]
+    .
+
+<https://hypothes.is/a/ipO-aqBPEe-VNFsaSPpvcA> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics\n\nThe repository enables reuse of the digital objects over time, ensuring that appropriate information is available to support understanding and use."
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://zenodo.org/records/7051012>
+    ]
+    .
+
+<https://hypothes.is/a/iXMy_qKJEe-aBG-QJvqC2A> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics \nThe PID manager SHOULD provide policies and contractual arrangements for transfer of ownership should the owner no longer be able to assume responsibilities in compliance with the policy."
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://zenodo.org/records/10067253>
+    ]
+    .
+
+<https://hypothes.is/a/j95nIKEnEe-SWgNCDr4jww> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics \n\nThe life cycle status of the repository: is it still being developed or in production and accepting data submissions? The latter does not exclude that some (re)development, enhancement or maintenance may be ongoing, as happens in any mature system."
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://zenodo.org/records/4084763>
+    ]
+    .
+
+<https://hypothes.is/a/j9h5XCMmEe-4HCdbJwo0gA> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics"
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://zenodo.org/records/7051012>
+    ]
+    .
+
+<https://hypothes.is/a/jHf0GqEoEe-0LjsJQVLffw> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics \n\nContact info (for the person, depositor, producer or owner, ideally with ORCID; or organisation) of the data: does the repository keep and show this information?"
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://zenodo.org/records/4084763>
+    ]
+    .
+
+<https://hypothes.is/a/K8kfsqDPEe-DlkOAJS6zew> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics"
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://www.nature.com/articles/s41597-020-0486-7> ;
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact "Adhering to the designated community’s metadata and curation standards, along with providing stewardship of the data holdings e.g. technical validation, documentation, quality control, authenticity protection, and long-term persistence." ;
+            oa:prefix "             \n                  " ;
+            oa:suffix "\n                \n              "
+        ]
+    ]
+    .
+
+<https://hypothes.is/a/kF4FNO0KEe2WFAfiLEZjOw> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "{Transparent}"
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://openscholarlyinfrastructure.org/> ;
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact "Transparent operations – achieving trust in the selection of representatives to governance groups will be best achieved through transparent processes and operations in general (within the constraints of privacy laws)." ;
+            oa:prefix "demographics of the membership.\n" ;
+            oa:suffix "\nCannot lobby – the community, n"
+        ]
+    ]
+    .
+
+<https://hypothes.is/a/Kfv66qGZEe-8xsdmT-l2cg> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics \nUse of Indigenous data invokes a reciprocal responsibility to enhance data literacy within Indigenous communities and to support the development of an Indigenous data workforce and digital infrastructure to enable the creation, collection, management, security, governance, and application of data"
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://www.gida-global.org/care>
+    ]
+    .
+
+<https://hypothes.is/a/lhbyZO0LEe2ikduaeVntiQ> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "{Formal Incentives]"
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://openscholarlyinfrastructure.org/> ;
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact "Formal incentives to fulfil mission & wind-down – infrastructures exist for a specific purpose and that purpose can be radically simplified or even rendered unnecessary by technological or social change. If it is possible the organisation (and staff) should have direct incentives to deliver on the mission and wind down." ;
+            oa:prefix "ur this same set of principles.\n" ;
+            oa:suffix "\n\nSustainability\n\nTime-limited f"
+        ]
+    ]
+    .
+
+<https://hypothes.is/a/Lnj5bKEpEe-wPjt4rZzeMQ> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics \n\nMechanism and process to make and track edits to a dataset after deposition: does the repository enable modification to the submitted dataset (e.g., to correct it or append additional information)? Is there a process to distinguish, link and access all versions of the data?"
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://zenodo.org/records/4084763>
+    ]
+    .
+
+<https://hypothes.is/a/LQtQnu2IEe2T218Oihfurw> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "{Contingency}"
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://openscholarlyinfrastructure.org/> ;
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact "Goal to create contingency fund to support operations for 12 months – a high priority should be generating a contingency fund that can support a complete, orderly wind down (12 months in most cases). This fund should be separate from those allocated to covering operating risk and investment in development." ;
+            oa:prefix "yond immediate operating costs.\n" ;
+            oa:suffix "\nMission-consistent revenue gene"
+        ]
+    ]
+    .
+
+<https://hypothes.is/a/lsSesKEJEe-PnAuH-1cAIA> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics\n \nThe repository provides or utilises persistent identifiers."
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://zenodo.org/records/11221855>
+    ]
+    .
+
+<https://hypothes.is/a/lv4UCqBREe-z1x9mmbfokw> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics"
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://www.nature.com/articles/s41597-020-0486-7> ;
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact "Providing (or contributing to) community catalogues to facilitate data discovery." ;
+            oa:prefix "             \n                  " ;
+            oa:suffix "\n                \n              "
+        ]
+    ]
+    .
+
+<https://hypothes.is/a/mB-QKqEKEe-pl2fcYSUe2A> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics\n\nPolicies for who can view and access a dataset and under what conditions."
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://zenodo.org/records/11221855>
+    ]
+    .
+
+<https://hypothes.is/a/MEHVsp9cEe-2yCNmBhtIDw> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics\n\nThe repository approach to changing and versioning data and metadata. How the approach and records of changes are communicated to data depositors and users."
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://zenodo.org/records/7051012>
+    ]
+    .
+
+<https://hypothes.is/a/MNN_niSMEe-lkSuC3jCIdw> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics"
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://zenodo.org/records/7051012>
+    ]
+    .
+
+<https://hypothes.is/a/ms4YFqKJEe-0H1_bze0geg> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics \nPID Services SHOULD aim for a persistence median that is acceptable to and aligns with community and dependency expectations."
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://zenodo.org/records/10067253>
+    ]
+    .
+
+<https://hypothes.is/a/MSuIru2KEe2GwTPOXF_8sQ> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "{No Patents}"
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://openscholarlyinfrastructure.org/> ;
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact "Patent non-assertion – The organisation should commit to a patent non-assertion covenant. The organisation may obtain patents to protect its own operations, but not use them to prevent the community from replicating the infrastructure." ;
+            oa:prefix "ilable via periodic data dumps.\n" ;
+            oa:suffix "\n\n\n\nCite as Bilder G, Lin J, Ney"
+        ]
+    ]
+    .
+
+<https://hypothes.is/a/MUCF1qGaEe-BPK8XoygNkw> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics \nData governance should take into account the potential future use and future harm based on ethical frameworks grounded in the values and principles of the relevant Indigenous community. Metadata should acknowledge the provenance and purpose and any limitations or obligations in secondary use inclusive of issues of consent."
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://www.gida-global.org/care>
+    ]
+    .
+
+<https://hypothes.is/a/mUlbSqGeEe-NpRt3sJz7wA> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics"
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://www.nature.com/articles/s41597-020-0486-7> ;
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact "TRUSTworthy repositories take responsibility for the stewardship of their data holdings and for serving their user community." ;
+            oa:prefix "ble data services.Responsibility" ;
+            oa:suffix " Responsibility is demonstrated "
+        ]
+    ]
+    .
+
+<https://hypothes.is/a/N8AhMp8zEe-0TC9dA8dCyQ> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desireable Characteristics\n\n... repository must identify the skills necessary to deliver the services it offers, and source and maintain those skills either as internal resources or through external engagement."
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://zenodo.org/records/7051012>
+    ]
+    .
+
+<https://hypothes.is/a/NEwRtKBVEe-VJg8lHAlA-w> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics\nThe repository assumes responsibility for long-term preservation and manages this function in a planned and documented way."
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://zenodo.org/records/7051012>
+    ]
+    .
+
+<https://hypothes.is/a/NhhEpqEWEe-3gpM7_XJx9g> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics\n\nDeposit and access agreements or licenses."
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://zenodo.org/records/7051012>
+    ]
+    .
+
+<https://hypothes.is/a/NkIYkKGXEe-neL9Dfi6_UA> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics \nIndigenous Peoples’ rights and interests in Indigenous data must be recognised and their authority to control such data be empowered. Indigenous data governance enables Indigenous Peoples and governing bodies to determine how Indigenous Peoples, as well as Indigenous lands, territories, resources, knowledges and geographical indicators, are represented and identified within data."
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://www.gida-global.org/care>
+    ]
+    .
+
+<https://hypothes.is/a/nNzUqKDMEe-tZrs2PDjcYw> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics\nReview and annotation of the data performed by the repository (e.g. via a data submission tool that enforces some curation, or by its curation team): are there a set of minimum curation steps that repository performs on the submitted data? Is there a webpage or document that describes the type of curation done? This criteria is also related to the Data and Metadata Standards criteria."
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://zenodo.org/records/4084763>
+    ]
+    .
+
+<https://hypothes.is/a/No97XqEoEe-wOEuBb_hiGQ> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics \n\nMechanism and process for sharing deposited data via a link anonymously (or otherwise depending on journal policy regarding open/closed review): does the repository allow confidential access to the data for peer-review? Does the repository also have capability for double blind peer review?"
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://zenodo.org/records/4084763>
+    ]
+    .
+
+<https://hypothes.is/a/NXo_eG5YEe6gDtPlsg-Tpg> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "GOvernance"
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://riojournal.com/article_preview.php?id=67379> ;
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact "Governance" ;
+            oa:prefix "        \n          \n            " ;
+            oa:suffix "\n            \n              \n   "
+        ]
+    ]
+    .
+
+<https://hypothes.is/a/o0mT8KJ9Ee-DZh_tPJWypQ> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics \nThe PID Manager MUST maintain entity metadata as accurately as possible in collaboration with the PID Owner. This copy is the authoritative version."
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://zenodo.org/records/10067253>
+    ]
+    .
+
+<https://hypothes.is/a/oC_KhiSIEe-irrtV2iX-Wg> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics"
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://www.nature.com/articles/s41597-020-0486-7> ;
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact "Planning sufficiently for risk mitigation, business continuity, disaster recovery, and succession." ;
+            oa:prefix "             \n                  " ;
+            oa:suffix "\n                \n              "
+        ]
+    ]
+    .
+
+<https://hypothes.is/a/OdCo9qKLEe-XqwNbu44RUg> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics \nPID services and PID Managers SHOULD have clear versioning policies."
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://zenodo.org/records/10067253>
+    ]
+    .
+
+<https://hypothes.is/a/Of9M2O0LEe2byOO26_Rk5Q> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "{Living Will}"
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://openscholarlyinfrastructure.org/> ;
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact "Living will – a powerful way to create trust is to publicly describe a plan addressing the condition under which an organisation would be wound down, how this would happen, and how any ongoing assets could be archived and preserved when passed to a successor organisation. Any such organisation would need to honour this same set of principles." ;
+            oa:prefix "ve environment that affects it.\n" ;
+            oa:suffix "\nFormal incentives to fulfil mis"
+        ]
+    ]
+    .
+
+<https://hypothes.is/a/Of9M2O0LEe2byOO26_Rk5Q> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "{Living Will}"
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://openscholarlyinfrastructure.org/> ;
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact "Living will – a powerful way to create trust is to publicly describe a plan addressing the condition under which an organisation would be wound down, how this would happen, and how any ongoing assets could be archived and preserved when passed to a successor organisation. Any such organisation would need to honour this same set of principles." ;
+            oa:prefix "ve environment that affects it.\n" ;
+            oa:suffix "\nFormal incentives to fulfil mis"
+        ]
+    ]
+    .
+
+<https://hypothes.is/a/oVKAMqGZEe-RxFf8W1rSHg> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics \nEthical data are data that do not stigmatise or portray Indigenous Peoples, cultures, or knowledges in terms of deficit. Ethical data are collected and used in ways that align with Indigenous ethical frameworks and with rights affirmed in UNDRIP. Assessing ethical benefits and harms should be done from the perspective of the Indigenous Peoples, nations, or communities to whom the data relate"
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://www.gida-global.org/care>
+    ]
+    .
+
+<https://hypothes.is/a/OWqUPKKJEe-Nh2ufWO-1fA> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics \nThe basic services of PID registration and resolution SHALL have no cost to end users."
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://zenodo.org/records/10067253>
+    ]
+    .
+
+<https://hypothes.is/a/PIwgTO2JEe2t7xNWZQGyxQ> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "{Open Data}"
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://openscholarlyinfrastructure.org/> ;
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact "Open data (within constraints of privacy laws) – For an infrastructure to be forked it will be necessary to replicate all relevant data. The CC0 waiver is best practice in making data legally available. Privacy and data protection laws will limit the extent to which this is possible" ;
+            oa:prefix " with running the organisation.\n" ;
+            oa:suffix "\nAvailable data (within constrai"
+        ]
+    ]
+    .
+
+<https://hypothes.is/a/PPZ__KGfEe-t9W_MUzmz-A> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics"
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://www.nature.com/articles/s41597-020-0486-7> ;
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact "A TRUSTworthy repository needs to focus on serving its target user community. Each user community likely has differing expectations from their community repositories, depending in part on the community’s maturity regarding data management and sharing. A TRUSTworthy repository is embedded in its target user community’s data practices, and so can respond to evolving community requirements" ;
+            oa:prefix "m (ethical standards).User Focus" ;
+            oa:suffix ". We take a broad view of ‘user "
+        ]
+    ]
+    .
+
+<https://hypothes.is/a/qbKjevQ6EfCC1NuBtGWoEQ> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "Governance and long-term preservation"
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://www.nature.com/articles/s41597-020-0486-7> ;
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact "Providing governance for necessary long-term preservation of data so that data resources remain discoverable, accessible, and usable in the future." ;
+            oa:prefix "             \n                  " ;
+            oa:suffix "\n                \n              "
+        ]
+    ]
+    .
+
+<https://hypothes.is/a/qeU8AqBaEe-cbMuPOqueoQ> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics"
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://www.nature.com/articles/s41597-020-0486-7> ;
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact "Having plans and mechanisms in place to prevent, detect, and respond to cyber or physical security threats" ;
+            oa:prefix "             \n                  " ;
+            oa:suffix ".\n                \n             "
+        ]
+    ]
+    .
+
+<https://hypothes.is/a/Qn_fRqKTEe-MyEuO3D-7ow> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "Encoding of PID Policy"
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://zenodo.org/records/10067253>
+    ]
+    .
+
+<https://hypothes.is/a/QOSwmiPpEe-ZVrsxMWs7HA> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics"
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://zenodo.org/records/7051012>
+    ]
+    .
+
+<https://hypothes.is/a/rb8jBqEnEe-qAN8ENIlcsw> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics \n\nPlan that gives information about sustainability plans for the repository: does the repository have a webpage, or document that describes these?"
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://zenodo.org/records/4084763>
+    ]
+    .
+
+<https://hypothes.is/a/RR_5OqGYEe-j-1f_AlLH2Q> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics \nIndigenous data are grounded in community values, which extend to society at large. Any value created from Indigenous data should benefit Indigenous communities in an equitable manner and contribute to Indigenous aspirations for wellbeing."
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://www.gida-global.org/care>
+    ]
+    .
+
+<https://hypothes.is/a/SBJaCCSSEe-1jtcjYD3BCw> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics"
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://www.nature.com/articles/s41597-020-0486-7> ;
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact "Managing the intellectual property rights of data producers" ;
+            oa:prefix "             \n                  " ;
+            oa:suffix ", the protection of sensitive in"
+        ]
+    ]
+    .
+
+<https://hypothes.is/a/sbYHqO2IEe2vbO8uqFgSLw> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "{Sustainable Operational Revenue}"
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://openscholarlyinfrastructure.org/> ;
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact "Revenue based on services, not data – data related to the running of the research enterprise should be a community property. Appropriate revenue sources might include value-added services, consulting, API Service Level Agreements or membership fees." ;
+            oa:prefix "the organisation. For instance…\n" ;
+            oa:suffix "\n\nInsurance\n\nOpen source – All s"
+        ]
+    ]
+    .
+
+<https://hypothes.is/a/SnQiLqBfEe-LrnNsTQtkQQ> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics"
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://www.nature.com/articles/s41597-020-0486-7> ;
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact "A repository depends on the interaction of people, processes, and technologies to support secure, persistent, and reliable services. Its activities and functions are supported by software, hardware, and technical services." ;
+            oa:prefix "       \n              Technology" ;
+            oa:suffix " Together, these provide the too"
+        ]
+    ]
+    .
+
+<https://hypothes.is/a/txDi4qEIEe-LAdfnCEw_GA> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics \n\nThe native language of the user interface of the repository"
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://zenodo.org/records/11221855>
+    ]
+    .
+
+<https://hypothes.is/a/u-aI1qBYEe-E-QeToRlkLA> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics\nDigital object management takes place according to defined workflows from deposit to access"
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://zenodo.org/records/7051012>
+    ]
+    .
+
+<https://hypothes.is/a/u3AdqCVIEe-3R9uagd20CQ> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics"
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://zenodo.org/records/7051012>
+    ]
+    .
+
+<https://hypothes.is/a/UcwtkqGZEe-9ko9gPZQwgw> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics \nResources must be provided to generate data grounded in the languages, worldviews, and lived experiences (including values and principles) of Indigenous Peoples."
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://www.gida-global.org/care>
+    ]
+    .
+
+<https://hypothes.is/a/UFiK8KEIEe-krq9Sbrh-PA> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics \n\nThe uniform resource locator (URL) that serves as the homepage and primary entry point for accessing the repository on the World Wide Web."
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://zenodo.org/records/11221855>
+    ]
+    .
+
+<https://hypothes.is/a/UiJZ8iSJEe-SA6fhqE9Mbg> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics"
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://www.nature.com/articles/s41597-020-0486-7> ;
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact "Ensuring sustainability of a TRUSTworthy repository is necessary to ensure uninterrupted access to its valuable data holdings for current and future user communities. Continued access to data is dependent upon the ability of the repository to provide services over time, and to respond with new or improved services to meet evolving user community requirements." ;
+            oa:prefix "   \n              Sustainability" ;
+            oa:suffix "A TRUSTworthy repository may dem"
+        ]
+    ]
+    .
+
+<https://hypothes.is/a/ukFUkOyOEe2QW1cu1u7n7Q> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "{Coverage}"
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://openscholarlyinfrastructure.org/> ;
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact "Coverage across the research enterprise – it is increasingly clear that research transcends disciplines, geography, institutions and stakeholders. The infrastructure that supports it needs to do the same." ;
+            oa:prefix "       \n            Governance\n\n" ;
+            oa:suffix "\nStakeholder Governed – a board-"
+        ]
+    ]
+    .
+
+<https://hypothes.is/a/uxB5TKBVEe-Mqg_SZLpo8A> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics\n\nThe repository addresses technical quality and standards compliance, and ensures that sufficient information is available for end users to make quality-related evaluations."
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://zenodo.org/records/7051012>
+    ]
+    .
+
+<https://hypothes.is/a/v_qoaqEJEe-OOjug00pwDw> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics \n\nApplication Programming Interfaces (APIs), service endpoints, and other protocol interfaces that enable machine access to a repository."
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://zenodo.org/records/11221855>
+    ]
+    .
+
+<https://hypothes.is/a/V2KaGKGXEe-0Pw9t6ph1dQ> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics \nThose working with Indigenous data have a responsibility to share how those data are used to support Indigenous Peoples’ self determination and collective benefit. Accountability requires meaningful and openly available evidence of these efforts and the benefits  accruing to Indigenous Peoples."
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://www.gida-global.org/care>
+    ]
+    .
+
+<https://hypothes.is/a/v8q5RiPKEe-CfqtAII7AGQ> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics"
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://www.nature.com/articles/s41597-020-0486-7> ;
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact "Managing the intellectual property rights of data producers, the protection of sensitive information resources, and the security of the system and its content." ;
+            oa:prefix "             \n                  " ;
+            oa:suffix "\n                \n              "
+        ]
+    ]
+    .
+
+<https://hypothes.is/a/vRKZRKEVEe-5jp920oPrIA> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics"
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://www.nature.com/articles/s41597-020-0486-7> ;
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact "Terms of use, both for the repository and for the data holdings." ;
+            oa:prefix "             \n                  " ;
+            oa:suffix "\n                \n              "
+        ]
+    ]
+    .
+
+<https://hypothes.is/a/vRKZRKEVEe-5jp920oPrIA> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics"
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://www.nature.com/articles/s41597-020-0486-7> ;
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact "Terms of use, both for the repository and for the data holdings." ;
+            oa:prefix "             \n                  " ;
+            oa:suffix "\n                \n              "
+        ]
+    ]
+    .
+
+<https://hypothes.is/a/vsKk_PQ8EfCDXi-DwWADLQ> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "Provide a short overview of key characteristics of the repository, reflecting the\nrepository type selected. This should include information about the scope and size of data\ncollections, data types and formats. Further contextual information may also be added"
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://zenodo.org/records/7051012>
+    ]
+    .
+
+<https://hypothes.is/a/VTYDhKBbEe-k2Qt2QhQOdg> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics"
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://www.nature.com/articles/s41597-020-0486-7> ;
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact "Implementing relevant and appropriate standards, tools, and technologies for data management and curation" ;
+            oa:prefix "             \n                  " ;
+            oa:suffix ".\n                \n             "
+        ]
+    ]
+    .
+
+<https://hypothes.is/a/vwOcIqEoEe-N8mfYHospJA> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics \n\nDeposition of data: are there any restrictions (e.g. by location, country, organisation, etc.) or can anyone from anywhere deposit data?"
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://zenodo.org/records/4084763>
+    ]
+    .
+
+<https://hypothes.is/a/WDzvUqEKEe-v7LNL9foboQ> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics \n\nPolicies that explain what datasets the repository will accept for deposit, from whom, and under what conditions, including costs."
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://zenodo.org/records/11221855>
+    ]
+    .
+
+<https://hypothes.is/a/wlmZeqGXEe-ZYK8jhcLNPg> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics \nGovernments and institutions must actively support the use and reuse of data by Indigenous nations and communities by facilitating the establishment of the foundations for Indigenous innovation, value generation, and the promotion of local self-determined development processes"
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://www.gida-global.org/care>
+    ]
+    .
+
+<https://hypothes.is/a/xAsYQKDSEe-5WtdJ33UD7w> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics\n\nGlobally unique and Persistent IDentifiers (PIDs): does the repository assign them to the deposited data? Which type of identifier schema is used?"
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://zenodo.org/records/4084763>
+    ]
+    .
+
+<https://hypothes.is/a/XgHBoKKWEe-ijDs8dsBvVQ> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics"
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://www.nature.com/articles/s41597-020-0486-7> ;
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact "Providing data services e.g. portal and machine interfaces, data download or server-side processing." ;
+            oa:prefix "             \n                  " ;
+            oa:suffix "\n                \n              "
+        ]
+    ]
+    .
+
+<https://hypothes.is/a/XqwEWO2JEe2yDP-oIkvnWQ> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "{Accessible}"
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://openscholarlyinfrastructure.org/> ;
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact "Available data (within constraints of privacy laws) – It is not enough that the data be made “open” if there is not a practical way to actually obtain it. Underlying data should be made easily available via periodic data dumps." ;
+            oa:prefix "xtent to which this is possible\n" ;
+            oa:suffix "\nPatent non-assertion – The orga"
+        ]
+    ]
+    .
+
+<https://hypothes.is/a/yA49ZKEnEe-W4xth8XyAeg> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics \n\nSupport to users during or after submission: does the repository have a contact point (e.g. helpdesk email or contact form) to assist data depositors and data users?"
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://zenodo.org/records/7051012>
+    ]
+    .
+
+<https://hypothes.is/a/YGXSaiPFEe-P939QgiKYpw> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics"
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://zenodo.org/records/7051012>
+    ]
+    .
+
+<https://hypothes.is/a/Yvmr_KEJEe-Lf5_eRwNzbQ> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics \n\nA general description of the data repository."
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://zenodo.org/records/11221855>
+    ]
+    .
+
+<https://hypothes.is/a/z87b9vQ5EfCU2RfDLdx8qA> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "Benefits and constraints transparently available"
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://www.nature.com/articles/s41597-020-0486-7> ;
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact "In order to select the most appropriate repository for a particular use case, all potential users benefit from being able to easily find and access information on the scope, target user community, policies, and capabilities of the data repository" ;
+            oa:prefix " size tableShow moreTransparency" ;
+            oa:suffix ". Transparency in these areas of"
+        ]
+    ]
+    .
+
+<https://hypothes.is/a/z8j90OyPEe2LOLe5AzAi2w> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "{Membership}"
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://openscholarlyinfrastructure.org/> ;
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact "Non-discriminatory membership – we see the best option as an “opt-in” approach with a principle of non-discrimination where any stakeholder group may express an interest and should be welcome. The process of representation in day to day governance must also be inclusive with governance that reflects the demographics of the membership." ;
+            oa:prefix "eration of different interests.\n" ;
+            oa:suffix "\nTransparent operations – achiev"
+        ]
+    ]
+    .
+
+<https://hypothes.is/a/zcnGfKKWEe-Am4utPhdi1w> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics"
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://www.nature.com/articles/s41597-020-0486-7> ;
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact "comprehensive policies supporting community-agreed practices" ;
+            oa:prefix "s, reliable infrastructure, and " ;
+            oa:suffix ". TDRs, with their clear remit t"
+        ]
+    ]
+    .
+
+<https://hypothes.is/a/ZoJTNCMmEe-s9GMl_cqmmw> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics\nIt is recognised that a repository may offer different levels of curation to different digital objects."
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://zenodo.org/records/7051012>
+    ]
+    .
+
+<https://hypothes.is/a/ZulkgqEnEe-wt3uk8M446Q> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics \nThe higher-level subject areas/disciplines the repository covers, as well as cross-disciplinary domains, such as the types or data, technology and study."
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://zenodo.org/records/4084763>
+    ]
+    .
+
+<https://hypothes.is/a/ZXpNEKEIEe-Ax2-ePhLmGg> a oa:Annotation ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value "TRSP Desirable Characteristics\n\nThe country in which the repository operates"
+    ] ;
+    oa:hasTarget [
+        a oa:SpecificResource ;
+        oa:hasSource <https://zenodo.org/records/11221855>
+    ]
+    .


### PR DESCRIPTION
Harvested 140 hypothes.is annotation(s) into `data/source/annotation.ttl` as Web Annotation (oa:) records.

Already present (skipped): 0
Not found: 7
Errors: 0