### PR TITLE
Hypothesis annotations: add 234 annotation(s)

### DIFF
--- a/data/source/annotation.ttl
+++ b/data/source/annotation.ttl
@@ -3640,3 +3640,6087 @@
             oa:suffix ""
         ]
     ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/2BEfKj-pEfGpWuvpj_fFCw>
+    a oa:Annotation ;
+    dct:subject "NER Test", "Australia", "Peru" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "**Australia** (https://example.org/vocab/iso3166-1-alpha-3/AUS)\nConfidence: 95%\n> den Proben, die Aug. V o g e l in Miinchen angestellt hat, wobei derselbe bemerkt, dass das Wasser aus verschie- denen Pumpbrunnen in quantitativer Hinaicbt nur geringe Vcrschiedenheit zeigte. Die Probe\n\n---\n\n**Peru** (https://example.org/vocab/iso3166-1-alpha-3/PER)\nConfidence: 95%\n> rgab, dass das Wasser eine 10 Milli- ramm Uebermangansaure zersetzende Menge or anischer gubstanaen per Liter enthielt, wogegen gutes f3runnen- wasser nur 1 bis 2 Milligramm Uebermangansiiure aer- setzen"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://zenodo.org/records/18925203/files/graphAfghanicaAbstract.pdf> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "den Proben, die Aug. V o g e l in Miinchen angestellt hat, wobei derselbe bemerkt, dass das Wasser aus verschie- denen Pumpbrunnen in quantitativer Hinaicbt nur geringe Vcrschiedenheit zeigte. Die Probe" ;
+            oa:prefix "" ;
+            oa:suffix ""
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/qlALwj-WEfGRFq-g0OIexQ>
+    a oa:Annotation ;
+    dct:subject "TRSP", "TRSP-designatedCommunity" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "info for annotation 2-1\n\nmanagement and nature of stakeholder dependencies - end user groupings, depositors, funders, service users and aggregators, including statements of intent in respect of partnership and stakeholder management and its improvement."
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://doi.org/10.5281/zenodo.7051012> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "management and nature of stakeholder dependencies - end user groupings, depositors, funders, service users and aggregators, including statements of intent in respect of partnership and stakeholder management and its improvement." ;
+            oa:prefix "" ;
+            oa:suffix ""
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/pphreD-WEfGjYMO7k1RACQ>
+    a oa:Annotation ;
+    dct:subject "TRSP", "TRSP-designatedCommunity" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "info for annotation 2-1\n\nManaged Stakeholder Dependencies - A document or web resource should be made available detailing the management and nature of stakeholder dependencies - end user groupings, depositors, funders, service users and aggregators, including statements of intent in respect of partnership and stakeholder management and its improvement."
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://doi.org/10.1038/s41597-020-0486-7> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "Managed Stakeholder Dependencies - A document or web resource should be made available detailing the management and nature of stakeholder dependencies - end user groupings, depositors, funders, service users and aggregators, including statements of intent " ;
+            oa:prefix "" ;
+            oa:suffix ""
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/UjEpCD-WEfGKSb-zg5IIHA>
+    a oa:Annotation ;
+    dct:subject "TRSP", "TRSP-designatedCommunity" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "info for annotation 2-1\n\nend user group-ings, depositors, funders, ser-vice users and aggre-gators, including statements of intent in respect of partner-ship and stake-holder management and its improvement."
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://doi.org/10.5281/zenodo.7051012> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "end user group-ings, depositors, funders, ser-vice users and aggre-gators, including statements of intent in respect of partner-ship and stake-holder management and its improvement." ;
+            oa:prefix "" ;
+            oa:suffix ""
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/T8yNQj-WEfGD59_sZxccfA>
+    a oa:Annotation ;
+    dct:subject "TRSP", "TRSP-designatedCommunity" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "info for annotation 2-1\n\na document or web resource should be made available detailing the management and nature of stakeholder dependencies - end user groupings, depositors, funders, service users and aggregators, including statements of intent in respect of partnership and stakeholder management and its improvement."
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://doi.org/10.1038/s41597-020-0486-7> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "a document or web resource should be made available detailing the management and nature of stakeholder dependencies - end user groupings, depositors, funders, service users and aggregators, including statements of intent in respect of partnership and stake" ;
+            oa:prefix "" ;
+            oa:suffix ""
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/EaxfJD-WEfGqSROix_FbNQ>
+    a oa:Annotation ;
+    dct:subject "TRSP", "TRSP-designatedCommunity" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "info for annotation 2-1\n\nstakeholder management and its improvement."
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://doi.org/10.5281/zenodo.7051012> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "stakeholder management and its improvement." ;
+            oa:prefix "" ;
+            oa:suffix ""
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/D4fgkj-WEfG69YdUq-mKrQ>
+    a oa:Annotation ;
+    dct:subject "TRSP", "TRSP-designatedCommunity" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "info for annotation 2-1\n\nManaged Stakeholder Dependencies - A document or web resource should be made available detailing the management and nature of stakeholder dependencies - end user groupings, depositors, funders, service users and aggregators, including statements of intent in respect of partnership and stakeholder management and its improvement."
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://doi.org/10.1038/s41597-020-0486-7> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "Managed Stakeholder Dependencies - A document or web resource should be made available detailing the management and nature of stakeholder dependencies - end user groupings, depositors, funders, service users and aggregators, including statements of intent " ;
+            oa:prefix "" ;
+            oa:suffix ""
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/ucQ38D8OEfGQHgc-2qgpoA>
+    a oa:Annotation ;
+    dct:subject "PID-benefits-test", "PID-issues-test" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "info for annotation 1\n\nOver time, the risk grows that the document is no longer accessible at the loca-tion given as reference. Web servers that follow the HTTP protocol then give the notorious reply: ‘404 not found’. This resembles the situation of a book in a – very large – library that is not on the shelf at the position indicated in the cata-logue. How is it to be found?"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://webdoc.sub.gwdg.de/edoc/ah/2006/hilse_kothe/urn:nbn:de:gbv:7-isbn-90-6984-508-3-8.pdf> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "Over time, the risk grows that the document is no longer accessible at the loca-tion given as reference. Web servers that follow the HTTP protocol then give the notorious reply: ‘404 not found’. This resembles the situation of a book in a – very large – li" ;
+            oa:prefix "" ;
+            oa:suffix ""
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/7WrRtD8NEfGCXCPFYbEW8w>
+    a oa:Annotation ;
+    dct:subject "PID", "PID-benefits", "PID-issues" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "info for annotation 1\n\nOver time the risk grows that the document is no longer accessible at the loca- tion given as reference. Web servers that follow the HTTP protocol then give the notorious reply: ‘404 not found’. This resembles the situation of a book in a – very large – library that is not on the shelf at the position indicated in the cata-logue. How is it to be found?"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://webdoc.sub.gwdg.de/edoc/ah/2006/hilse_kothe/urn:nbn:de:gbv:7-isbn-90-6984-508-3-8.pdf> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "Over time the risk grows that the document is no longer accessible at the loca- tion given as reference. Web servers that follow the HTTP protocol then give the notorious reply: ‘404 not found’. This resembles the situation of a book in a – very large – li" ;
+            oa:prefix "" ;
+            oa:suffix ""
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/Yzzzgj8NEfGYwa-VTzUfiw>
+    a oa:Annotation ;
+    dct:subject "PID", "PID-benefits", "PID-issues" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "info for annotation 1\n\nOver time, the risk grows that the document is no longer accessible at the loca- tion given as reference. Web servers that follow the HTTP protocol then give the notorious reply: ‘404 not found’. This resembles the situation of a book in a – very large – library that is not on the shelf at the position indicated in the cata-logue. How is it to be found?"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://webdoc.sub.gwdg.de/edoc/ah/2006/hilse_kothe/urn:nbn:de:gbv:7-isbn-90-6984-508-3-8.pdf> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "Over time, the risk grows that the document is no longer accessible at the loca- tion given as reference. Web servers that follow the HTTP protocol then give the notorious reply: ‘404 not found’. This resembles the situation of a book in a – very large – l" ;
+            oa:prefix "" ;
+            oa:suffix ""
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/eLHd-D8JEfGy_--cqjVmVQ>
+    a oa:Annotation ;
+    dct:subject "TRSP", "TRSP-designatedCommunity" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "info for annotation 2\n\nThe CoreTrustSeal Requirements describe the characteristics required to be a trustworthy repository for digital data and metadata. Each Requirement is accompanied by Guidance text describing the response statements and evidence that applicants must provide to enable an objective review."
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://doi.org/10.5281/zenodo.7051012> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "The CoreTrustSeal Requirements describe the characteristics required to be a trustworthy repository for digital data and metadata. Each Requirement is accompanied by Guidance text describing the response statements and evidence that applicants must provide" ;
+            oa:prefix "" ;
+            oa:suffix ""
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/wimeMHD7EfCOUitU7dl9Cw>
+    a oa:Annotation ;
+    dct:subject "cat_FAIR", "cat_F1", "cat_WHAT" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Persistent identifier"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://fairaware.dans.knaw.nl/> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "A persistent identifier is a long-lasting reference to a resource.\n            The data(set) you deposit in a\n            data repository should be assigned a globally unique, persistent and resolvable identifier (PID) so that\n            both humans and machines can find it. Persistent identifiers are maintained and governed so that they remain\n            stable and direct the users to the same relevant object consistently over time. Examples of PIDs include\n            Digital Object Identifier (DOI),\n            Handle, and\n            Archival Resource Key (ARK)." ;
+            oa:prefix "   What does this mean?\n        " ;
+            oa:suffix "\n        Why is this important?\n"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/K2TDzuUbEe-jDjNz09kbhg>
+    a oa:Annotation ;
+    dct:subject "PID Resolution", "PID_Metaresolver" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Example metaresolver"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://faircore4eosc.eu/eosc-core-components/eosc-pid-meta-resolver-pidmr> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "The PID Meta Resolver is a generalized resolver for mapping items into records. The  PID Meta Resolver will know where to route different types of identifiers – e.g. DOI or URN:NBN. The PID Meta Resolver will improve machine based data processing and will allow getting digital object information without in-depth knowledge of the resolution mechanism of different PID systems. That enhances the compilation and analysis of data collections originating not only from different sources but also referenced by different PID systems." ;
+            oa:prefix "integrate different systems.  \n\n" ;
+            oa:suffix "\n\nThe component will include the"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/cub4xuUaEe-2gdca7hPLvA>
+    a oa:Annotation ;
+    dct:subject "PID Resolution", "PID_Metaresolver" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Example of a metaresolver"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://n2t.net/> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "N2T is an identifier scheme resolver that given a provided identifier,\n        matches it to an identifier scheme definition. Depending on the form of the request,\n        a successful match will either redirect to the registered target or present\n        information about the matched definition." ;
+            oa:prefix "ier Resolution Service\n    \n    " ;
+            oa:suffix "\n    Identifiers take the form:\n"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/9hOe6uUYEe-HdTfKnEMaJQ>
+    a oa:Annotation ;
+    dct:subject "PID Resolution" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Cascading resolver infrastructure"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://www.doi.org/doi-handbook/DOI_Handbook_Final.pdf> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "EVELOPING A DOI RESOLVER" ;
+            oa:prefix "e is as described in 7.4.1.7.5 D" ;
+            oa:suffix "For your DOI application, you ma"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/rVMqUqKKEe-iSZdLmqU7KQ>
+    a oa:Annotation ;
+    dct:subject "TRSP", "PID", "Sustainability", "Continuity" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "TRSP Desirable Characteristics \nPID Service Providers MUST have a clear sustainability and succession plan with an exit strategy that guarantees the continuity of the resolution of its PIDs registered with the service."
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://zenodo.org/records/10067253> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "" ;
+            oa:prefix "" ;
+            oa:suffix ""
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/YLM1oqKKEe-Nisd32W1ZJA>
+    a oa:Annotation ;
+    dct:subject "TRSP", "PID", "Services", "Availability", "Documentation" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "TRSP Desirable Characteristics \nPID Service Providers SHOULD document a summary of their maintenance and availability provisions publicly."
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://zenodo.org/records/10067253> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "" ;
+            oa:prefix "" ;
+            oa:suffix ""
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/NjjtlKKKEe-9q_fsypTMjQ>
+    a oa:Annotation ;
+    dct:subject "PID", "TRSP", "Services", "Uptime", "Availability" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "TRSP Desirable Characteristics \nPID Services MUST meet 999 availability and uptime."
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://zenodo.org/records/10067253> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "" ;
+            oa:prefix "" ;
+            oa:suffix ""
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/nOQcMqGYEe--Qvt43sMaNw>
+    a oa:Annotation ;
+    dct:subject "TRSP", "CARE", "FAIR, CARE, TRUST - Adoption, Implementation, and Deployment", "Authority to Control", "Data for Governance" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "TRSP Desirable Characteristics \nIndigenous Peoples have the right to data that are relevant to their world views and empower self-determination and effective self-governance. Indigenous data must be made available and accessible to Indigenous nations and communities in order to support Indigenous governance."
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://www.gida-global.org/care> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "" ;
+            oa:prefix "" ;
+            oa:suffix ""
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/VsWL3qEoEe-X0l--AgmcZQ>
+    a oa:Annotation ;
+    dct:subject "TRSP", "DRS-CTM", "Related Identifier Support" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "TRSP Desirable Characteristics \n\nA mechanism to enable link datasets to related articles or pre-prints: does the repository enable this at submission stage or post-submission?"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://zenodo.org/records/4084763> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "" ;
+            oa:prefix "" ;
+            oa:suffix ""
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/LnZKvqCYEe--VtN2H8rc6g>
+    a oa:Annotation ;
+    dct:subject "TRSP", "DRS-CTM", "Certification" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "TRSP Desirable Characteristics\n\nCertification schemes and/or community badges that assess certain aspects of the repository (e.g., its fitness, trustworthiness, adoption): does the repository have any?"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://zenodo.org/records/4084763> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "10.5281/zenodo.4084762" ;
+            oa:prefix "e all versions by using the DOI " ;
+            oa:suffix ". This DOI represents all versio"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/PWMmzJ9eEe--MbdibmCq3w>
+    a oa:Annotation ;
+    dct:subject "TSRP-CTS Provenance" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "TRSP Desirable Characteristics\n\nThe provenance information and audit trails recorded for data and metadata processing and versioning."
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://zenodo.org/records/7051012> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "" ;
+            oa:prefix "" ;
+            oa:suffix ""
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/RRfU4HccEe-BAGv-5ZDx2w>
+    a oa:Annotation ;
+    dct:subject "" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "This is simply not true. Less energy will be available from fossil sources, but in many countries renewable energy is price competitive already and likely to become more so."
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://ipres2024.pubpub.org/pub/1sm257xx> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "As oil becomes more expensive to extract, less and less energy will be available." ;
+            oa:prefix " cheap oil is coming to an end. " ;
+            oa:suffix " Second, the byproducts of burni"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/ZpQ1sHTrEe-gTp_WBO2JHA>
+    a oa:Annotation ;
+    dct:subject "CAT Maturity" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Maturity Level 5"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://en.wikipedia.org/wiki/Capability_Maturity_Model> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "Efficient - process management includes deliberate process optimization/improvement." ;
+            oa:prefix "dance with agreed-upon metrics.\n" ;
+            oa:suffix "\nWithin each of these maturity l"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/S3En3nTrEe-E6qerNf8vrQ>
+    a oa:Annotation ;
+    dct:subject "CAT Maturity" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Maturity Level 4"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://en.wikipedia.org/wiki/Capability_Maturity_Model> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "Capable - the process is quantitatively managed in accordance with agreed-upon metrics." ;
+            oa:prefix " as a standard business process\n" ;
+            oa:suffix "\nEfficient - process management "
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/N0ow8nTrEe-KbmPmlftExg>
+    a oa:Annotation ;
+    dct:subject "CAT Maturity" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Maturity Level 3"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://en.wikipedia.org/wiki/Capability_Maturity_Model> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "Defined - the process is defined/confirmed as a standard business process" ;
+            oa:prefix "he same steps may be attempted.\n" ;
+            oa:suffix "\nCapable - the process is quanti"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/GreJRHTrEe-2Ym9k8WanKg>
+    a oa:Annotation ;
+    dct:subject "CAT Maturity" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Maturity Level 2"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://en.wikipedia.org/wiki/Capability_Maturity_Model> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "Repeatable - the process is at least documented sufficiently such that repeating the same steps may be attempted." ;
+            oa:prefix "or undocumented repeat process.\n" ;
+            oa:suffix "\nDefined - the process is define"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/wJ2sgnTpEe-H38OO1Xb1tQ>
+    a oa:Annotation ;
+    dct:subject "CAT Maturity" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Maturity Level 1"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://en.wikipedia.org/wiki/Capability_Maturity_Model> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "Initial (chaotic, ad hoc, individual heroics) - the starting point for use of a new or undocumented repeat process." ;
+            oa:prefix "ate supports this belief\".[18]\n\n" ;
+            oa:suffix "\nRepeatable - the process is at "
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/75AOVnDcEe-IoKcaPgUjVA>
+    a oa:Annotation ;
+    dct:subject "PID Standards" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            ""
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://fairsharing.org/FAIRsharing.e33260> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "ISO 24619:2011 specifies requirements for the persistent identifier (PID) framework and for using PIDs for referencing and citing documents, files and language resources (e.g digital dictionaries, text corpora, linguistic annotated corpora). A PID is an electronic identification referring to or citing electronic documents, files, resources, resource collections such as books, articles, papers, images etc. ISO 24619:2011 also addresses issues of persistence and granularity of references to resources, first by requiring that persistent references be implemented by using a PID framework and further by imposing requirements on any PID frameworks used for this purpose." ;
+            oa:prefix "t Registry Standard Description " ;
+            oa:suffix " Homepagehttps://www.iso.org/sta"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/IdqxoGwTEe-OtzsmoXFHzg>
+    a oa:Annotation ;
+    dct:subject "PID Availability" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Example of availability"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <http://status.ror.org/> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "All Systems Operational" ;
+            oa:prefix "        \n          \n            " ;
+            oa:suffix "\n          \n          \n        \n"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/VWZ02F8kEe-uAD8GiO9okA>
+    a oa:Annotation ;
+    dct:subject "PID Schema" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "ARCHON Schema definition"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://archiveshub.jisc.ac.uk/identifiers/> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "The Anatomy of References" ;
+            oa:prefix "dify the references. \n          " ;
+            oa:suffix "\n           The reference consis"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/juGLnl73Ee-_4GPVLF0_Ow>
+    a oa:Annotation ;
+    dct:subject "PID Persistence", "PID GUPRI", "PID ARCHON" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "ARCHON is not guaranteed to be persistent"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://archiveshub.jisc.ac.uk/identifiers/> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "We cannot guarantee persistence of identifiers, because we do not generate and maintain the data" ;
+            oa:prefix "hanging environment. \n          " ;
+            oa:suffix ". But we can make every effort t"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/TDlr9EmAEe-Rkf_ceAmlAw>
+    a oa:Annotation ;
+    dct:subject "dfg:OrganisationName" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            ""
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://www.wikidata.org/wiki/Special:EntityData/Q821542.jsonld> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "DataCite" ;
+            oa:prefix "uage\": \"de\",\n        \"@value\": \"" ;
+            oa:suffix "\"\n      }\n    },\n    {\n      \"@i"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/tAFBlg0QEe-YWhcV4JD7Bw>
+    a oa:Annotation ;
+    dct:subject "PID Standards" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "PID Standard Software"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://www.inchi-trust.org/download-latest-inchi-standard-software/> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "free open-source software to load and write chemical structures" ;
+            oa:prefix "The InChi Trust makes available " ;
+            oa:suffix ".   In order to keep users of th"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/nxaz8g0PEe-9Zt_MKa3odA>
+    a oa:Annotation ;
+    dct:subject "PID Metrics" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "PID Start"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://pbs.twimg.com/media/Dsiex63WsAA5EEv?format=jpg&name=4096x4096> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "" ;
+            oa:prefix "" ;
+            oa:suffix ""
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/7XERlg0KEe-a3mueYZ7mzw>
+    a oa:Annotation ;
+    dct:subject "PID Metrics" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "PID Start Date"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://drive.google.com/file/d/1x4qnYJdIYG9i0qPtw-kVfsRHAO2foSgi/view> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "" ;
+            oa:prefix "" ;
+            oa:suffix ""
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/mGcY4AzcEe-TGr85n3Akkg>
+    a oa:Annotation ;
+    dct:subject "PID Metrics" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "PID Started"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://en.wikipedia.org/wiki/Catalogue_of_Life> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "It was created in 2001" ;
+            oa:prefix "nts, fungi, and microorganisms. " ;
+            oa:suffix " as a partnership between the gl"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/kR03KAzbEe-h9L-Ua_OUzA>
+    a oa:Annotation ;
+    dct:subject "PID Metrics" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "PID Count"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://www.wikidata.org/wiki/Property:P10585> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "4,463,574" ;
+            oa:prefix "umber of records\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n" ;
+            oa:suffix "\n\n\n\n\n\n\n\npoint in time\n\n\n\n\n13 Jan"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/H1feUgzTEe-y4yfeDsu88Q>
+    a oa:Annotation ;
+    dct:subject "PID Metrics" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "PID Count"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://www.wikidata.org/wiki/Q118398> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "2,400,000" ;
+            oa:prefix " exhibition size\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n" ;
+            oa:suffix " scholarly article\n\n\n\n\n\n\n\n\n1 ref"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/kHaNxAnZEe-rIV_ZqzGyjA>
+    a oa:Annotation ;
+    dct:subject "PID Stacks", "PID" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            ""
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://www.islrn.org/> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "The International Standard Language Resource Number (ISLRN) is a new, unique and\n            universal identification schema for Language Resources which provides Language Resources\n            with unique names using a standardized nomenclature. It also ensures Language Resources\n            are identified, and consequently recognized with proper references in activities within\n            Human Language Technologies, as well as in documents and scientific papers." ;
+            oa:prefix " is ISLRN?\n        \n            " ;
+            oa:suffix "\n            more...\n        \n  "
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/WRV7UsXvEe6LIYNa2Uu7Sw>
+    a oa:Annotation ;
+    dct:subject "" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Call b.s. when you see it ... plants are green because they reflect most of the green frequency range - opposite of penetration."
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://boulderlamp.com/light-spectrum-and-photosynthesis/> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "Green spectrum also penetrates deep into plants driving photosynthesis where other spectrum cannot." ;
+            oa:prefix "omote higher biomass and yield. " ;
+            oa:suffix "\t\t\t\t\t\n\n\n\n\nFar Red (700-800nm):\t\t"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/wnfclMDpEe6tAnNhVoVljw>
+    a oa:Annotation ;
+    dct:subject "" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "logies tool is used to collect, maintain"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://mscr-test.rahtiapp.fi/vocabularies> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "" ;
+            oa:prefix "" ;
+            oa:suffix ""
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/jZr9crv3Ee6j31OeSESnig>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Best Practices", "PID Stakeholders", "PID Governance" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "PID - Governance"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://info.orcid.org/orcid-researcher-advisory-council/> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "The ORCID Researcher Advisory Council (ORAC) is a diverse group of researchers who provide valuable perspectives and advice to ORCID staff and the ORCID Board to ensure that ORCID provides value and utility to researchers and facilitates research and innovation." ;
+            oa:prefix "ID Researcher Advisory Council\n\n" ;
+            oa:suffix "\n\n\n\nTo ensure that we keep the r"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/dlKZbLn6Ee6AC5fpuNtgZg>
+    a oa:Annotation ;
+    dct:subject "" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Interesting."
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://www.dona.net/sites/default/files/2020-11/Summary_of_Board_Minutes_July%201-2%2C_2020.pdf> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "Mr. Wittenburg started by thanking the Executive Director who had provided useful inputs relating to EOSCdiscussions in Western Europe. In Mr. Wittenburg's view the DO Architecture technology was now facingtwo main challenges: (i) building such infrastructure was taking more time than it had initially beenexpected; and (ii) building such infrastructure was still a highly dynamic issue as there were many differentsuggestions and positions among the players. For Mr. Wittenburg, a DONA strength was that it was an islandof stability in this dynamic environment" ;
+            oa:prefix "zation for this kind of project." ;
+            oa:suffix ".Mr. Gao thanked the Executive D"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/7hxIJIlVEe65Xav62x8ZNg>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Benefits" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Sustainable resource discovery"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://zenodo.org/records/3620845> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "" ;
+            oa:prefix "" ;
+            oa:suffix ""
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/zb8QgofMEe638YsuE8KWrg>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Features", "Versioning" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "PID Versioning"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://help.figshare.com/article/can-i-edit-or-delete-my-research-after-it-has-been-made-public> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "Figshare supports version control of all publicly available data. Any privately stored data can also be altered or deleted as you wish." ;
+            oa:prefix "er it has been made public?Yes, " ;
+            oa:suffix "If you have accidentally publish"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/tQBx8n5AEe6Wwl-_r3btag>
+    a oa:Annotation ;
+    dct:subject "" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Presentation quotes"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://genius.com/Neil-young-crime-in-the-city-sixty-to-zero-part-1-lyrics> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "The artist looked at the producerThe producer sat backHe said, \"What we have got here, is a perfect trackBut we don't have a vocalAnd we don't have a songIf we could get these things accomplishedNothing else could go wrong\"So he balanced the ashtrayAs he picked up the phoneAnd said, \"Send me a songwriterWho's drifted far from homeAnd make sure that he's hungryMake sure he's aloneSend me a cheeseburgerAnd a new Rolling Stone\"" ;
+            oa:prefix "rAnd the story was told[Verse 2]" ;
+            oa:suffix "YeahYou might also likeDon’t Cry"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/MkU_Mm-8Ee6_4dutSIHZmA>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Best Practices", "Tagging" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Manuscript tagging"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://igsn.github.io/syntax/> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "In a journal article or manuscript a sample identified by IGSN SSH000SUA may look like this (tagged IGSN):\n\nIGSN:SSH000SUA" ;
+            oa:prefix "use the syntax\n\nIGSN: <IGSN> \n\n\n" ;
+            oa:suffix "\n\nTagging IGSNs in manuscripts i"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/NrNCcm-7Ee6c5POggY0pvg>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Best Practices" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Human-readable"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://igsn.github.io/syntax/> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "Unlike many other persistent identifiers, an IGSN is used not only used by machines but also needs to be handled by humans." ;
+            oa:prefix "ntation.\n\nRecommended Practice\n\n" ;
+            oa:suffix " The labelling of sample contain"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/RKrcqG-uEe67Kd_vivOQGQ>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Issues" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            ""
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <http://www.hyam.net/blog/archives/325> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "Without some kind of persistence mechanism the only advantage of LSIDs is that they look like they are supposed to be persistent. Unfortunately, because many people are using UUIDs as their object identifiers LSIDs actually look like something you wouldn’t want to look at let alone expose to a user! CoL actually hide them because they look like this:\nurn:lsid:catalogueoflife.org:taxon:d755ba3e-29c1-102b-9a4a-00304854f820:ac2009" ;
+            oa:prefix " the latest version of the RDF.\n" ;
+            oa:suffix "\nNo normal person is going to re"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/Lkcwfm-uEe6EuQ9NYFyuUQ>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Features", "Persistence" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            ""
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <http://www.hyam.net/blog/archives/325> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "The act of minting an LSID indicates that you intend to try to make it permanent or at least never re-use it for another resource." ;
+            oa:prefix "used for everything on the web. " ;
+            oa:suffix "\nThe barrier to everyone hosting"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/25yQBG7uEe6-AyMGb__kCg>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Schema", "Emerging PID Schemes" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Preferred PID Scheme"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://riojournal.com/article_preview.php?id=67379> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "The preferred PID scheme\n            \n              In consideration of the foregoing, the strongest option across the studied major dimensions of the available Handle System PID schemes and operational modes is for DiSSCo to use DOIs to identify Digital Specimens. The case for choosing DOI comes out slightly more strongly than choosing ePIC for reasons related to the substantial achievements, operational experience and reputation of DOI/ IDF to date. Operating under another Handle-system prefix than those used by IDF and ePIC is the substantially weakest option because of the difficulties associated with introducing an identifier that is not perceived to be a DOI. The term ‘DOI’ is trademarked by the IDF and thus not available for describing other identifiers.\n              The practical and sensible avenue to explore further are the options to establish and become an RA member of the DOI Foundation (option A5) and to enter a strategic alliance at the level of the DOI Foundation (option A1). These options are likely most effective when actioned in combination." ;
+            oa:prefix "        \n          \n            " ;
+            oa:suffix "\n            \n          \n       "
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/-BDCpm7tEe64-T8Rg1NYqA>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Use Cases", "Workflows" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Workflows"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://riojournal.com/article_preview.php?id=67379> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "When digitized, each resulting ‘Digital Specimen’ must be persistently and unambiguously identified. Subsequent events or transactions associated with the Digital Specimen, such as annotation and/or modification by a scientist must be recorded, stored and also unambiguously identified." ;
+            oa:prefix "blicly available.\n              " ;
+            oa:suffix "\n              Suppl. material 2"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/PzTTTm7tEe62rWv_pRTLxw>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Use Cases" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Use case"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://riojournal.com/article_preview.php?id=67379> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "Persistent identifiers (PID) to identify digital representations of physical specimens in natural science collections (i.e., digital specimens) unambiguously and uniquely on the Internet are one of the mechanisms for digitally transforming collections-based science." ;
+            oa:prefix "\n              \n                " ;
+            oa:suffix " Digital Specimen PIDs contribut"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/1wBIQG7rEe65v0vPIFNGYg>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Benefits", "Precision" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Information quality=precision"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://riojournal.com/article_preview.php?id=67379> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "Information quality is the strongest factor to influence organizational benefits through perceived usefulness and user satisfaction" ;
+            oa:prefix " Trustworthiness should follow. " ;
+            oa:suffix " (Park et al. 2011).\n           "
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/gg8btG5ZEe692sfOL76MvQ>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Entities" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Entity"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://riojournal.com/article_preview.php?id=67379> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "Digital Specimen" ;
+            oa:prefix "       \n                        " ;
+            oa:suffix "\n                      \n        "
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/kKpMxm5YEe6m4YdlVXGNqQ>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Best Practices", "PID Use Cases" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Appropriate"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://riojournal.com/article_preview.php?id=67379> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "Appropriate identifiers\n            \n              \n                \n                  Requirement: PIDs appropriate to the digital object type being persistently identified." ;
+            oa:prefix "        \n          \n            " ;
+            oa:suffix "\n                \n              "
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/zuDnnm5XEe6Rpnf1X2YWJg>
+    a oa:Annotation ;
+    dct:subject "_FI_", "Persistence", "PID Features" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Persistence"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://riojournal.com/article_preview.php?id=67379> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "Persistence" ;
+            oa:prefix "        \n          \n            " ;
+            oa:suffix "\n            \n              \n   "
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/NsMCCG5XEe6VqEunKiJy4Q>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Features", "Trust" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Trust"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://riojournal.com/article_preview.php?id=67379> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "Trust" ;
+            oa:prefix "        \n          \n            " ;
+            oa:suffix "\n            \n              \n   "
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/5TW22G5WEe61LmOTJazBUg>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Features", "Topology" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Topology if Handle-based schemes"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://riojournal.com/article_preview.php?id=67379> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "Available Handle-based PID schemes" ;
+            oa:prefix "   \n        \n        \n          " ;
+            oa:suffix "\n          \n            The Hand"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/robnkm5WEe61LSfeJUPmyQ>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Features", "FAIR" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Comparing FAIRness of PIDs"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://content.iospress.com/articles/data-science/ds190024> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "Which identifiers are FAIR enough?" ;
+            oa:prefix "gh resolution or sameAs links.5." ;
+            oa:suffix "Just how “persistent” are PIDs r"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/pfmmZG1XEe6od8d5CY8sSA>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Features" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Characteristics"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://www.nature.com/articles/sdata201829> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "Compact identifiers are a longstanding informal convention in bioinformatics. To be used as globally unique, persistent, web-resolvable identifiers, they require a commonly agreed namespace registry with maintenance rules and clear governance; a set of redirection rules for converting namespace prefixes, provider codes and local identifiers to resolution URLs; and deployed production-quality resolvers with long-term sustainability." ;
+            oa:prefix "-term sustainable way.Discussion" ;
+            oa:suffix " An example of formal referencin"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/kOgqvmz_Ee6hQwOZLVu0Fw>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Entities" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            ""
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://content.iospress.com/articles/data-science/ds190024> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "digital or physical objects, or concepts" ;
+            oa:prefix "tifiers in science may refer to " ;
+            oa:suffix ". PIDs such as ORCIDs (Open Rese"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/8vddrmwWEe62wtdk7LgwcQ>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Features", "Persistence" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Characteristics"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://zenodo.org/records/1116189> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "Wittenburg, P., Hellström, M., Zwölf, C.-M., Abroshan, H., Asmi, A., Di Bernardo, G., Couvreur, D., Gaizer, T., Holub, P., Hooft, R., Häggström, I., Kohler, M., Koureas, D., Kuchinke, W., Milanesi, L., Padfield, J., Rosato, A., Staiger, C., van Uytvanck, D., & Weigel, T. (2017). Persistent identifiers: Consolidated assertions. Status of November, 2017. Zenodo. https://doi.org/10.5281/zenodo.1116189" ;
+            oa:prefix "\n      \n    \n  \n\n  Citation\n  \n\n" ;
+            oa:suffix "StyleAPAAPAHarvardMLAVancouverCh"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/3LxeUGtwEe685RNbbmEd-w>
+    a oa:Annotation ;
+    dct:subject "PID Issues", "_FI", "PID Benefits" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Benefits"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://webdoc.sub.gwdg.de/edoc/ah/2006/hilse_kothe/urn:nbn:de:gbv:7-isbn-90-6984-508-3-8.pdf> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "Breaking of links is mostly due to administrative changes at the referencedInternet node" ;
+            oa:prefix "g’ document is presentedinstead." ;
+            oa:suffix ". Broken links have a negative i"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/eXVEeGtYEe6ntG_XETHFkQ>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Issues", "PID Benefits" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "PID Issues"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://webdoc.sub.gwdg.de/edoc/ah/2006/hilse_kothe/urn:nbn:de:gbv:7-isbn-90-6984-508-3-8.pdf> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "Over time the risk grows that the document is no longer accessible at the loca-tion given as reference. Web servers that follow the HTTP protocol then givethe notorious reply: ‘404 not found’. This resembles the situation of a book in a– very large – library that is not on the shelf at the position indicated in the cata-logue. How is it to be found?" ;
+            oa:prefix "ng documents, e.g. in acitation." ;
+            oa:suffix "It would be even worse if no suc"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/zC4WyGtXEe6eKXvwXDQcwg>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Benefits" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "History"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://webdoc.sub.gwdg.de/edoc/ah/2006/hilse_kothe/urn:nbn:de:gbv:7-isbn-90-6984-508-3-8.pdf> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "In the mid 1990s, a number of schemes were developed that, rather than rely-ing on the precise address of a document, introduced the idea of name spaces forrecording the names and locations of documents." ;
+            oa:prefix "y inacces-sible to the end-user." ;
+            oa:suffix " The identifiers for documentsar"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/QtjjrGpjEe64BzMNVPTrkg>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Features", "Service Levels" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Characteristics"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://www.crossref.org/membership/terms/> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "Archives. The Member shall use best efforts to contract with a third-party archive or other content host (an \"Archive\") (a list of which can be found here) for such Archive to preserve the Member's Content and, in the event that the Member ceases to host the Member's Content, to make such Content available for persistent linking." ;
+            oa:prefix "registered by a prior publisher." ;
+            oa:suffix " The Member hereby authorizes Cr"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/1TCF5GpiEe6yuK8kUTKzmQ>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Features", "Service Levels" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Characteristics"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://www.crossref.org/membership/terms/> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "Maintaining and Updating Metadata." ;
+            oa:prefix "hyperlinked so as to be citable." ;
+            oa:suffix " The Member shall ensure that ea"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/VsE_fmphEe64TXv1xhZJAg>
+    a oa:Annotation ;
+    dct:subject "PID Best Practices", "Tombstone" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Characteristics"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://datacite.org/wp-content/uploads/2023/08/DataCite_ConsortiumMembershipTerms_20220802.pdf> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "withdrawing content withoutposting a notification (“Tombstone Page”) andupdating the record's URL/metadata with DataCite" ;
+            oa:prefix "gistering themwith DataCite; 2) " ;
+            oa:suffix "; or3) registering new Identifie"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/GcS1JGphEe6RCicSjRxCaw>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Features", "Service Levels" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Characteristics"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://datacite.org/wp-content/uploads/2023/08/DataCite_ConsortiumMembershipTerms_20220802.pdf> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "Commitment to data persistence" ;
+            oa:prefix "o the following requirements:a. " ;
+            oa:suffix ".b. Transmission of Metadata acc"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/4tAGrmpgEe68nGfvXO_RoQ>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Features", "Service Levels" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Characteristics"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://datacite.org/wp-content/uploads/2023/08/DataCite_ConsortiumMembershipTerms_20220802.pdf> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "Maintaining and Updating Metadata." ;
+            oa:prefix "ds of the researchdiscipline.c. " ;
+            oa:suffix " The ConsortiumLead or Consortiu"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/eOr7ompdEe6kFk9rb8VOKg>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Features", "Certification" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Characteristics"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://www.pidconsortium.net/?page_id=1060> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "ePIC PID service, and an organisation, that provides a PID service and is not an ePIC member, can ask for a certification, that it provides its PID service along the lines of the ePIC rules and policies." ;
+            oa:prefix "ID service, that is provided as " ;
+            oa:suffix " This certification includes top"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/B-QiOmpdEe6x0Wf2zMGydQ>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Features", "PID Providers" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Characteristics"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://www.pidconsortium.net/?page_id=1060> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "ePIC has rules and policies, how to provide PID services and how to ensure the reliability, that is necessary for the persistency of access to digital objects via ePIC PIDs." ;
+            oa:prefix "r providing an ePIC PID service?" ;
+            oa:suffix " These rules and policies have t"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/Bx-7ZGlqEe6fkmP2XJ46eA>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Features", "Scalability" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Characteristics"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://datascience.codata.org/articles/10.5334/dsj-2017-013> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "Scalability – in the data/metadata stored;" ;
+            oa:prefix "entifiers while catering for:\n\n\n" ;
+            oa:suffix "\n\nIntegrity – ensuring data is b"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/r_vyOmlpEe6frV_CgkzZLQ>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Features", "Scalability" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Characteristics"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://riojournal.com/article_preview.php?id=67379> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "Scalability" ;
+            oa:prefix "        \n          \n            " ;
+            oa:suffix "\n            \n              \n   "
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/BAmFPmliEe6IC-uzOASETw>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Metrics", "Persistence" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Persistence Maximum"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://en.wikipedia.org/wiki/ORCID> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "ORCID was first announced in 2009" ;
+            oa:prefix ".\n\nDevelopment and launch[edit]\n" ;
+            oa:suffix " as a collaborative effort by pu"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/TTgQHmlhEe6_lee_9YNiQw>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Metrics", "Persistence" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Persistence Maximum"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://en.wikipedia.org/wiki/Digital_object_identifier> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "The developer and administrator of the DOI system is the International DOI Foundation (IDF), which introduced it in 2000" ;
+            oa:prefix "nk, leaving the DOI useless.[7]\n" ;
+            oa:suffix ".[8] Organizations that meet the"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/uD1SYmjFEe6y8tM6iAVR5g>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Kernel Metadata" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "ARK Kernel Metadata Query"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://www.ietf.org/archive/id/draft-kunze-thump-03.txt> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "5.2.  Key ? was(DESCRIPTION) when(DATE) resync\n\n   This \"metadata\" command form provides nothing more than a way to\n   carry a Key along with its description.  The form is a \"no-op\"\n   (except when \"resync\" is present) in the sense that the Key is\n   treated as an adorned URL (as if no THUMP request were present).\n   This form is designed as a passive data structrue that pairs a\n   hyperlink with its metadata so that a formatted description might be\n   surfaced by a client-side trigger event such as a \"mouse-over\".  It\n   is passive in the sense that selecting (\"clicking on\") the URL should\n   result in ordinary access via the Key-as-pure-link as if no THUMP\n   request were present.  The form is effectively a metadata cache, and\n   the DATE of last extraction tells how fresh it is.\n\n   The \"was\" pseudo-command takes multiple arguments separated by \"|\",\n   the first argument identifying the kind of DESCRIPTION that follows,\n   e.g," ;
+            oa:prefix " server to see if it is alive.\n\n" ;
+            oa:suffix "\n\n\n\nKunze & Nassar          Expi"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/5qbeLGjDEe66qI8_WLdwCA>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Features", "PID Resolution" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Characteristics"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://www.ietf.org/archive/id/draft-kunze-ark-34.html> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "To resolve a Compact ARK (ie, an ARK beginning \"ark:\") it must initially\nbe promoted to a Mapping ARK so that it becomes actionable.\n\nOn the web, this means finding a suitable web Resolver Service to prepend\nto the compact form of the identifier in order to convert it to a URL (cf\n[CURIE]).\n(This is more or less true for any type of identifier not already in\nURL form.)" ;
+            oa:prefix "lver Chains and Roles\n        \n\n" ;
+            oa:suffix "¶\n\nThe identifier's Resolver Ser"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/mWNOJGh0Ee6aXoNWRpVpBw>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Features", "Sustainability" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Characteristics"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://riojournal.com/article_preview.php?id=67379> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "Collectively the IDF and its RA members assume the long-term responsibility to maintain and sustain the DOI PID scheme for everyone." ;
+            oa:prefix "rs by the DOI Foundation (IDF). " ;
+            oa:suffix "\n            \n          \n       "
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/8BO02GhwEe6Z-N87Q-lIPg>
+    a oa:Annotation ;
+    dct:subject "_FI_", "Tombstone", "PID Features" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Characteristics"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://www.pidconsortium.net/?page_id=1060> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "Registered production PIDs will not be deleted. They are used as a kind of tombstone even if the underlying data is not available anymore." ;
+            oa:prefix "ide ePIC?\nePIC PIDs are unique.\n" ;
+            oa:suffix "\nThose PIDs, that have a prefix "
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/gAfwvmhmEe6K9-vsrMtRZQ>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Providers" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "ePIC Members"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://www.pidconsortium.net/?page_id=74> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "CLARIN: European Research Infrastructure for Language Resources and Technology\nCNIC: Computer Network Information Center, Chinese Academy of Sciences, China\nCSC: IT Center for Science\nCSCS: Swiss National Supercomputing Centre\nDKRZ: Deutsches Klimarechenzentrum\nGRNET: Greek Research and Technology Network\nGWDG: Gesellschaft für wissenschaftliche Datenverarbeitung Göttingen\nSND: Swedish National Data Center\nSURF: SURF is the collaborative ICT organization for higher education and research in the Netherlands" ;
+            oa:prefix "nsist of the following members:\n" ;
+            oa:suffix "\nThe management board of the con"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/Is_r7GhkEe63C_Mka6BdqA>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Benefits" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Definition"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://www.pidconsortium.net/?page_id=1060> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "Persistent identifiers (PIDs) are an abstraction layer that arbitrates between the reference of a digital object and its location." ;
+            oa:prefix "t are PIDs and what are Handles?" ;
+            oa:suffix " Since URLs as location tend to "
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/Mjj9SGgBEe6-WctSuW0Spw>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Features", "PID Best Practices", "Versioning" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Characteristics"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://support.datacite.org/docs/tombstone-pages> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "When content underlying a DOI is updated, we recommend updating the DOI metadata and, for major changes, assigning a new DOI.\n\nFor minor content changes, the same DOI may be used with updated metadata. A new DOI is not required.\nFor major content changes, we recommend assigning a new DOI and linking the new DOI to the previous DOI with related identifiers." ;
+            oa:prefix "wered by VersioningSuggest Edits" ;
+            oa:suffix "\n\nIndividual stewards may determ"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/90dSUmgAEe6iSz9brHIDlA>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Features", "PID Best Practices", "Landing Page" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Characteristics"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://support.datacite.org/docs/tombstone-pages> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "To enable easy usability for both humans and machines, a DOI should resolve to a landing page that contains information about the DOI being resolved. It is the responsibility of the entity creating the DOI to provide such a landing page. The following are best practices for creating well-formed DOI landing pages." ;
+            oa:prefix "r DOI Landing PagesSuggest Edits" ;
+            oa:suffix " \nBest Practices\nDOIs should res"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/qgRJjGgAEe62OYMbSbEGmg>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Features", "PID Best Practices", "Tombstone" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Characteristics"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://support.datacite.org/docs/tombstone-pages> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "there may be infrequent cases where it is not desirable for the item described by a DOI to be available publicly, such as in the case of research retraction. In these cases, it is best practice to still provide a \"tombstone page\", which is a special type of landing page describing the item that has been removed." ;
+            oa:prefix "DOI cannot be deleted. However, " ;
+            oa:suffix " Tombstone pages are generally t"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/L2LyMGf4Ee6kXwOs4A4uFw>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Features" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Certification\nThis potentially includes many of the features of PIDs already listed"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://datascience.codata.org/articles/10.5334/dsj-2017-039> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "certification: If certified, acronym for certification organization or standard (e.g., TRAC, TDR, DSA) and year of certification." ;
+            oa:prefix "und to keep references intact.\n\n" ;
+            oa:suffix "\n\nAlthough information about the"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/diGi7mf3Ee6163P1b42B3A>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Features" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Mission"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://datascience.codata.org/articles/10.5334/dsj-2017-039> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "mission: One sentence mission statement of the organization." ;
+            oa:prefix "t (FP) or not for profit (NP).\n\n" ;
+            oa:suffix "\n\nA crucial part of persistence "
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/PD0dxGf3Ee6LN1NtOvN-YQ>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Features" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Characteristics"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://datascience.codata.org/articles/10.5334/dsj-2017-039> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "business model: For profit (FP) or not for profit (NP)." ;
+            oa:prefix "entifier for the organization.\n\n" ;
+            oa:suffix "\n\nmission: One sentence mission "
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/i4qFemf2Ee6mjt-m6G83yQ>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Features" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Provider Identity"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://datascience.codata.org/articles/10.5334/dsj-2017-039> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "name: Full name of the provider organization.\n\nidentifier: Unique identifier for the organization." ;
+            oa:prefix "fier service and forwarding).\n\n\n" ;
+            oa:suffix "\n\nbusiness model: For profit (FP"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/RxiYCGeeEe6qFluhwXZnyQ>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Issues" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Mitigation"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://datascience.codata.org/articles/10.5334/dsj-2017-039> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "check character (CC): A check character is incorporated in the assigned identifier to guard against common transcription errors." ;
+            oa:prefix "gnizable semantic information.\n\n" ;
+            oa:suffix "\n\n\n\nThe nature of the provider\nA"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/kjd6CGeYEe6ei7_Ye8Rp1w>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Features", "Mediation", "Content Negotiation" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Expectations\nA form of content negotiation"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://datascience.codata.org/articles/10.5334/dsj-2017-039> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "inflection: a change to the ending of an object’s id string in order to obtain a reference to content related to the originally referenced content." ;
+            oa:prefix "nce link to create a new link.\n\n" ;
+            oa:suffix "\nInflections are not meant for t"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/KeG_CmeXEe6x5w8k3SHbqA>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Features", "Human-Readable" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Expectations"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://datascience.codata.org/articles/10.5334/dsj-2017-039> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "landing: content intended mostly for human consumption, such as an object description and links to primary information (e.g., an image file or a spreadsheet), to alternate versions and formats, and to related information; from “landing page”, this is intended to support a browsing experience of an abstract overall view of the object." ;
+            oa:prefix "er is a plunging experience.\n\n\n\n" ;
+            oa:suffix "\n\nplunging: content intended as "
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/_WE1ZGeWEe6qUhOeYNDtfw>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Features", "Machine-Readable" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Expectations"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://datascience.codata.org/articles/10.5334/dsj-2017-039> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "plunging: content intended as primary object information, often required or directly usable by software; from “below the landing page”, this is intended to support an immersive object experience that bypasses any browsing step." ;
+            oa:prefix "ct overall view of the object.\n\n" ;
+            oa:suffix "\n\nDesire from the scholarly comm"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/FO1spGeVEe6idqvkED-fmg>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Features", "Dynamic Citation" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Expectations"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://ieeexplore.ieee.org/document/6691588/> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "We propose a novel approach relying on persistent, timestamped, adapted queries to versioned and timestamped data sources" ;
+            oa:prefix "it copies of data do not scale. " ;
+            oa:suffix ". Result set hashes are used for"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/11MP2meTEe6eOedetc6oqg>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Policy", "Resource Availability" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Expectations"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://dans.knaw.nl/wp-content/uploads/2023/03/DANS-Data-Stations-Policy.pdf> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "Datafiles can be published with a suitable embargo period, forinstance to allow completion of publications or research basedon the dataset, or to respect contracts made by the depositorwith third parties concerning intellectual property rights.DANS encourages embargo periods of 6 months or less." ;
+            oa:prefix "ption ResponsibilityH.1 Embargo " ;
+            oa:suffix "DANS as CuratorH.2 Limitations t"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/bh_3XmeSEe6XOk-sGLQr3Q>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Features", "PID Policy" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Expectations"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://dans.knaw.nl/wp-content/uploads/2023/03/DANS-Data-Stations-Policy.pdf> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "If a published dataset is improved by amendments to thedata files of the dataset, a major version increment iscreated with a record of changes. In cases where it isnecessary to disable access to earlier versions, these can bedeaccessioned" ;
+            oa:prefix "positorG.3.2 Case 2:Data Changes" ;
+            oa:suffix ".DANS as CuratorDANS as ServiceP"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/263ZWmeQEe6c0YNQkIagxg>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Features" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Expectations"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://datascience.codata.org/articles/10.5334/dsj-2017-039> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "introversioned: a kind of intraversioned content for which the version identifier (within the object identifier) is opaque, e.g., “http://doi.org/10.2345/678”, which happens to be version 4." ;
+            oa:prefix "http://doi.org/10.2345/67.V4”.\n\n" ;
+            oa:suffix "\n\nThese three kinds of practice "
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/sJfJkmeQEe6czy-gNzjFHA>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Features" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Expectations"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://datascience.codata.org/articles/10.5334/dsj-2017-039> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "intraversioned: a version identifier is part of the id string, e.g., “http://doi.org/10.2345/67.V4”." ;
+            oa:prefix "oi.org/10.2345/67”, Version 4.\n\n" ;
+            oa:suffix "\n\nintroversioned: a kind of intr"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/B6nKfGeNEe6454uKnVLh9A>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Features" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Expectations"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://datascience.codata.org/articles/10.5334/dsj-2017-039> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "extraversioned: a version identifier is separate from the id string, so that the actionable id does not lead to specific version without human intervention, e.g., “http://doi.org/10.2345/67”, Version 4." ;
+            oa:prefix "o one of the following cases:\n\n\n" ;
+            oa:suffix "\n\nintraversioned: a version iden"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/ayQ6mmeKEe65KHMgfig7-A>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Features" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Trigger"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://datascience.codata.org/articles/10.5334/dsj-2017-039> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "Precisely when such assignment will be triggered depends on policy that will differ across objects, collections, and providers." ;
+            oa:prefix "eel to assign a new identifier. " ;
+            oa:suffix " Some of this thinking has origi"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/xZO39GeJEe6GoqMvECec0w>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Features" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Expectations\nDynamic Citation"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://datascience.codata.org/articles/10.5334/dsj-2017-039> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "waxing: change that is limited to appending content in a way that does not in itself disrupt or displace previously recorded content. Examples of waxing objects include live sensor-based data feeds, citation databases, and serial publications." ;
+            oa:prefix "e have a term for such growth:\n\n" ;
+            oa:suffix "\n\n\nPolicies on object and versio"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/V3JDxmeJEe6XCa_D61iTGQ>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Features" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Expectations"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://datascience.codata.org/articles/10.5334/dsj-2017-039> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "subinfinite: due to succession arrangements, the object is expected to be available beyond the provider organization’s lifetime." ;
+            oa:prefix "s long as the provider exists.\n\n" ;
+            oa:suffix "\n\n\n\nSetting user expectations: o"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/wk4c_GeIEe68lZMqamvYFA>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Features" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Expectations"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://datascience.codata.org/articles/10.5334/dsj-2017-039> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "lifetime: the object is expected to be available as long as the provider exists." ;
+            oa:prefix "ular commitment to the object.\n\n" ;
+            oa:suffix "\n\nsubinfinite: due to succession"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/f25ntmeIEe6GHUOtckO-_g>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Features" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Expectations"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://datascience.codata.org/articles/10.5334/dsj-2017-039> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "indefinite: the provider has no particular commitment to the object." ;
+            oa:prefix "event (e.g., single-use link).\n\n" ;
+            oa:suffix "\n\nlifetime: the object is expect"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/SmW0DGeIEe6E6q8JCSkmrQ>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Features" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Expectations"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://datascience.codata.org/articles/10.5334/dsj-2017-039> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "finite: availability is expected to end on or around a given date (e.g., limited support for software versions not marked “long term stable”) or trigger event (e.g., single-use link)." ;
+            oa:prefix "to keep the object available.\n\n\n" ;
+            oa:suffix "\n\nindefinite: the provider has n"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/FxpPGGeIEe6TuRMnY71oNA>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Features" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Expectations\n\n'Indefinite' should rather be 'Undefined'"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://datascience.codata.org/articles/10.5334/dsj-2017-039> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "finite: availability is expected to end on or around a given date (e.g., limited support for software versions not marked “long term stable”) or trigger event (e.g., single-use link).\n\nindefinite: the provider has no particular commitment to the object.\n\nlifetime: the object is expected to be available as long as the provider exists.\n\nsubinfinite: due to succession arrangements, the object is expected to be available beyond the provider organization’s lifetime." ;
+            oa:prefix "to keep the object available.\n\n\n" ;
+            oa:suffix "\n\n\n\nSetting user expectations: o"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/Rkun-GdxEe6O9NeKld30FA>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Features" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Expectations"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://datascience.codata.org/articles/10.5334/dsj-2017-039> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "We define content variance to be a description of the ways in which provider policy or practice anticipates how an object’s content will change over time. Approaches to content variance differ depending on the object, version, service, and provider." ;
+            oa:prefix " expectations: content variance\n" ;
+            oa:suffix "\nTo keep things simple, we assum"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/FX558mdxEe6pV1uAW84-ZA>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Features" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Expectations"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://datascience.codata.org/articles/10.5334/dsj-2017-039> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "molting: Previously recorded content may be entirely overwritten at any time with content that preserves thematic continuity. For example, an organization’s homepage may be completely reworked while continuing to be its homepage, and a weather or financial service page may reflect dramatic changes in conditions several times a day." ;
+            oa:prefix "ses any change under “fixing”.\n\n" ;
+            oa:suffix "\n\n\n\nSetting user expectations: o"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/22OCOmdwEe6hp3NwLZNo4A>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Features" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Expectations"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://datascience.codata.org/articles/10.5334/dsj-2017-039> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "rising: Previously recorded content may be improved at any time, for example, with better metadata (datasets), new features (software), or new insights (pre- and post-prints). This encompasses any change under “fixing”" ;
+            oa:prefix "to any change under “keeping”.\n\n" ;
+            oa:suffix ".\n\nmolting: Previously recorded "
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/lgBl0mdwEe6ICn9iw51k_A>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Features" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Expectations"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://datascience.codata.org/articles/10.5334/dsj-2017-039> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "fixing: Previously recorded content may be corrected at any time, in addition to any change under “keeping”" ;
+            oa:prefix "amination, security patching).\n\n" ;
+            oa:suffix ".\n\nrising: Previously recorded c"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/cDKfMmdwEe64jQdyVahOSw>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Features" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Expectations"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://datascience.codata.org/articles/10.5334/dsj-2017-039> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "keeping: Previously recorded content will not change, but character, compression, and markup encodings may change during a format migration, and high-priority security concerns will be acted upon (e.g., software virus decontamination, security patching)." ;
+            oa:prefix "orded content will not change.\n\n" ;
+            oa:suffix "\n\nfixing: Previously recorded co"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/73LLYGdvEe6Nsve6Xihf8w>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Features" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Expectations"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://datascience.codata.org/articles/10.5334/dsj-2017-039> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "frozen: The bit stream representing previously recorded content will not change" ;
+            oa:prefix "ne of the following policies:\n\n\n" ;
+            oa:suffix ".\n\nkeeping: Previously recorded "
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/6H_lXmdgEe6Ml8skYl79nA>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Features", "PID Usage" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Expectations"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://dev.to/electromorphous/what-are-persistent-identifiers-and-why-we-need-them-4i0c> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "Once a DOI is registered in the DOI System server, or repository, it will be stored there virtually forever." ;
+            oa:prefix " where the DOI data are stored. " ;
+            oa:suffix " That centrally stored data form"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/8SxBamdIEe6MPnMIZLYzDQ>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Features", "PID Resolution" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Classes of identifier"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://datascience.codata.org/articles/10.5334/dsj-2017-039> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "id string: the sequence of characters that is the identifier string itself, possibly modified by adding a well-known prefix (often starting with http://) in order to turn it into a URL.\n\nidentifier: an association between an id string and a thing; e.g., an identifier “breaks” when the association breaks, but to act on an identifier requires its id string.\n\nactionable identifier: an identifier whose id string may be acted upon by widely available software systems such as web browsers; e.g., URLs are actionable identifiers." ;
+            oa:prefix "need some identifier notions.\n\n\n" ;
+            oa:suffix "\n\nIf it were made queryable, the"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/VG5vKmdHEe6sHE8FuL1zDQ>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Issues" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Versioning"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://datascience.codata.org/articles/10.5334/dsj-2017-039> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "On the other hand, the universal numeric fingerprint (Altman & King 2007) is a PID that supports citation of numeric data in a way that is largely immune to the syntactic formatting and packaging of the data" ;
+            oa:prefix " references the latest version. " ;
+            oa:suffix ". In the particular case of evol"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/pPyQ5Gc3Ee681IuBFXVxxQ>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Issues" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Versioinng"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://dans.knaw.nl/wp-content/uploads/2023/03/DANS-Data-Stations-Policy.pdf> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "Data Management: Provenance, Versioning, and ReliableIdentification" ;
+            oa:prefix "rsion 1.1, September 26, 2023G. " ;
+            oa:suffix "# Provision Description Responsi"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/SHxYrmc3Ee6Vp8e_kXGZAA>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Issues" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Versioning"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://datascience.codata.org/articles/10.5334/dsj-2017-039> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "By contrast, repositories such as figshare (figshare 2016) and Merritt (Abrams et al. 2011) tolerate changes to metadata under the PID assigned originally, but create a new “versioned” PID if the object title or a component file changes, and in the latter case, the original non-versioned PID always references the latest version" ;
+            oa:prefix "on of an object (DataONE 2015). " ;
+            oa:suffix ". On the other hand, the univers"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/-vpoCmc2Ee6Ubs8v85kD9A>
+    a oa:Annotation ;
+    dct:subject "PID Issues", "_FI_" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Versioning"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://datascience.codata.org/articles/10.5334/dsj-2017-039> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "The DataONE federated data network (Michener et al. 2011) assigns a PID to immutable data objects and a “series identifier” that resolves to the latest version of an object (DataONE 2015)." ;
+            oa:prefix "rategies in use may be helpful. " ;
+            oa:suffix " By contrast, repositories such "
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/1IKoCmc1Ee6f_oeGLYuBrg>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Benefits" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Citation stability"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://datascience.codata.org/articles/10.5334/dsj-2017-039> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "Hey, T, Tansley, S and Tolle, K (2009). The Fourth Paradigm: Data-Intensive Scientific Discovery In: Redmond, Washington: Microsoft Research." ;
+            oa:prefix "[Last accessed 22 May 2017]. \n\n\n" ;
+            oa:suffix "  \n\n\nJones, S M, Van de Sompel, "
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/7cEwOmc0Ee6rvi8Xnj3CIQ>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Issues", "PID Benefits" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Median life of Thomson-Reuters"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://bmcbioinformatics.biomedcentral.com/articles/10.1186/1471-2105-14-S14-S5> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "median lifespan of these web pages was 9.3 years" ;
+            oa:prefix "996 and 2010 and found that the " ;
+            oa:suffix " with 62% of them being archived"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/yKnuXmcvEe6SYnOPOYXhhw>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Features", "PID Issues" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Persistence"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://datascience.codata.org/articles/10.5334/dsj-2017-039> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "At a minimum it implies a prediction about an archive’s commitment and capacity to provide some specific kind of long-term functionality" ;
+            oa:prefix "s a service is a broad concept. " ;
+            oa:suffix ". A single provider might suppor"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/7Kqg2GcuEe6fursTWCwZsQ>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Features", "PID Issues" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Persistence"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://datascience.codata.org/articles/10.5334/dsj-2017-039> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "persistence is purely a matter of service" ;
+            oa:prefix "t when we next need it, but its " ;
+            oa:suffix ", not conferred by or inherent i"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/0jSpCmcqEe629k9EhaWHIg>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Issues", "Content Drift" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Content Drift"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://blogs.lse.ac.uk/impactofsocialsciences/2015/02/05/reference-rot-in-web-based-scholarly-communication/> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "Content drift describes the case where the resource identified by its URI changes over time and hence, as time goes by, the request returns content that becomes less and less representative of what was originally referenced." ;
+            oa:prefix "404 – Page not found” response. " ;
+            oa:suffix "\nOur recent study, part of the r"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/2DiuomWiEe6_srtTEIODIA>
+    a oa:Annotation ;
+    dct:subject "_FI_" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Handle system introduction"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://en.wikipedia.org/wiki/Handle_System> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "The Handle System was first implemented in autumn 1994, and was administered and operated by CNRI until December 2015, when a new \"multi-primary administrator\" (MPA) mode of operation was introduced" ;
+            oa:prefix "d Wide Web, with similar goals.\n" ;
+            oa:suffix ". The DONA Foundation[3] now adm"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/2c3YamTjEe6HobOZNj1eEg>
+    a oa:Annotation ;
+    dct:subject "_FI_", "API" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "API"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://info.arxiv.org/help/bulk_data/index.html> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "arXiv API\nDataCite API using provider-id = arxiv" ;
+            oa:prefix "Xiv.\nThe metadata options are:\n\n" ;
+            oa:suffix "\nKaggle\n\nFull text options are:\n"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/obAsGGTiEe6ojDO4s63nkg>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Metrics" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Number of ArXiv PIDs"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://arxiv.org/> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "2,340,117" ;
+            oa:prefix " and an open-access archive for " ;
+            oa:suffix "     scholarly articles in the f"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/224LQmTXEe6klidV5OY17w>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Features", "PID Resolution" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "PID Resolution factors"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://browse.arxiv.org/pdf/2004.03011.pdf> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "These findings provide strong indicators that scholarly contentproviders reply to DOI requests differently, depending on the request method,the originating network environment, and institutional subscription levels" ;
+            oa:prefix "on the HTTP requestmethod used. " ;
+            oa:suffix ". Ourscholarly record, to a larg"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/cd6kdmTHEe6kb8dKIbSdIg>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Scope" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "PID Scope"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://insights.uksg.org/articles/10.1629/uksg.457> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "In addition, PIDs may be local to an individual organization (e.g. identifiers in an internal human resources system), national (e.g. the DAI – Digital Author Identifier, used in the Netherlands), or global (all the examples in the paragraph above)." ;
+            oa:prefix "available under a CC0 license.4\n" ;
+            oa:suffix "\nWhile there is no requirement f"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/vM9nFGTGEe6eGuuvOshN6Q>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Usage", "PID Entities" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "PID Entities - research outputs"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://insights.uksg.org/articles/10.1629/uksg.457> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "identifiers for research objects and outputs, for example, DOIs (digital object identifiers), Archival Resource Key identifiers (ARKs), handles and IGSNs (International Geo Sample Number)." ;
+            oa:prefix "esearch Organization Registry2\n\n" ;
+            oa:suffix "\n\nPIDs may be open, i.e. fully i"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/itAqMmTGEe6JzqP2dIoT_g>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Entities", "PID Usage" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "PID Entities - organisations"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://insights.uksg.org/articles/10.1629/uksg.457> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "identifiers for organizations, including GRID (Global Research Identifier Database), Ringgold IDs, ISNIs (International Standard Name Identifiers), LEIs (legal entity identifiers) and the identifiers that will be provided by the recently announced Research Organization Registry2" ;
+            oa:prefix "s, ResearcherIDs and Scopus IDs\n" ;
+            oa:suffix "\n\nidentifiers for research objec"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/KF71BGTGEe60rwOffMFMqg>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Entities", "PID Usage" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "PID Entities - Researchers"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://insights.uksg.org/articles/10.1629/uksg.457> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "identifiers for researchers, such as ORCID iDs, ResearcherIDs and Scopus IDs" ;
+            oa:prefix "grouped into three main types:\n\n" ;
+            oa:suffix "\nidentifiers for organizations, "
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/EsKXwGQaEe6U_nNpxvQyGQ>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Adoption Metrics", "PID Registry" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "lksjdfglsdkjfalsdjkh"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://arks.org/about/comparing-arks-and-other-identifiers/> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "To use open infrastructure consistent with your organization’s values." ;
+            oa:prefix " resolving your identifiers.\n\n\n\n" ;
+            oa:suffix "\n\n\n\nTo link directly to the obje"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/A_b5BmN2Ee6BjaPbZcvOlg>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID ISSN Registrations" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Number of ISSN Records"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://www.issn.org/wp-content/uploads/2023/02/Total-number-of-records.pdf> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "2 287 852" ;
+            oa:prefix "0 2 121 389 2 175 883 2 235 523 " ;
+            oa:suffix "of which new CR 61 139 73 880 58"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/hwOqAGKWEe6mtUsdt6gq7A>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Benefits" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Benefits"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://arks.org/about/comparing-arks-and-other-identifiers/> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "Reasons to use ARK" ;
+            oa:prefix "other identifier systems\t\n\n\t\n\t\t\n" ;
+            oa:suffix "s as compared to DOIs\n\n\n\n\nTo kee"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/OtGpemKWEe6j0Ld-Mz-sdw>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Benefits", "PID Costs" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "PID Costs"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://arks.org/about/comparing-arks-and-other-identifiers/> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "To keep costs down. While some ARK service providers exist, ARKs can be implemented locally with open-source tools." ;
+            oa:prefix "se ARKs as compared to DOIs\n\n\n\n\n" ;
+            oa:suffix "\n\n\n\nTo work with exactly the met"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/iAnR4mKFEe6RqIeouDdbuA>
+    a oa:Annotation ;
+    dct:subject "PID Kernel Metadata", "_FI_" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "ARK Metadata"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://arks.org/about/ark-features/> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "ARK systems such as Noid and N2T can record and provide metadata about any resource with an ARK.  That metadata becomes available via APIs, and can be seen when you add “?” to the end of an ARK URL. (See “Inflections” below)\n\n\n\nARK metadata is very flexible, with no initial required metadata, but with support for multiple metadata schemas.  This flexibility is intentional: ARKs are designed to support a full digital object workflow, including the earliest stages before a resource is well-understood or described." ;
+            oa:prefix "the digital object lifecycle\n\n\n\n" ;
+            oa:suffix "\n\n\n\nPeople need identifiers befo"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/o58MSGKEEe6LHA-sskTFSg>
+    a oa:Annotation ;
+    dct:subject "ARK", "_FI_", "PID Registry" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "PID Registry"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://arks.org/about/ark-naans-and-systems/> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "The ARK Alliance maintains a complete registry of all assigned NAANs, currently at the California Digital Library. The registry is mirrored at the (U.S.) National Library of Medicine and the National Library of France." ;
+            oa:prefix "th a dozen different NAANs. \n\n\n\n" ;
+            oa:suffix "\n\n\n\nYou can request a change to "
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/sy3iHmH0Ee619a-UQC1VYQ>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Stakeholders" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Stakeholders"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://popjournal.ca/issue03/goddard> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "stakeholders" ;
+            oa:prefix ". The national consortia gather " ;
+            oa:suffix " into a critical mass in order t"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/faWeZl4bEe68ndMxsvDQtw>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Benefits" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Benefits"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://popjournal.ca/issue03/goddard> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "PIDs are exemplary implementations of FAIR data in their own right, but they also help to provide FAIR access to research entities like articles and datasets." ;
+            oa:prefix " assets (Wilkinson et al 2016). " ;
+            oa:suffix "\nAll of the PID providers discus"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/d3AnNF4ZEe6pOVPObkktbA>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Features" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Integrity"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://popjournal.ca/issue03/goddard> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "DOIs are a great solution for the problem of URIs that change over time, but this approach does depend on journal publishers, repositories, libraries, and other major hosting organization to be responsible for maintaining current link information within the DOI records that they have created" ;
+            oa:prefix "current location of an article.\n" ;
+            oa:suffix ". One of the most important thin"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/kAuFzl4XEe6rLLfP9TEvKg>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Benefits", "PID Use Cases" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Use Case"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://popjournal.ca/issue03/goddard> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "Ultimately the knowledge graph will permit a much clearer understanding of global research networks, research impact, and the ways in which knowledge is created in a highly interconnected world." ;
+            oa:prefix "tions perform on those metrics. " ;
+            oa:suffix "\n\n        \n                \n    "
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/FrZCvl4WEe6KoLvAdc74_g>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Benefits", "PID Use Cases" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Use Case"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://popjournal.ca/issue03/goddard> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "PIDs infrastructure promises much more accurate and timely reporting for key metrics including the number of publications produced at an institution in a given year, the total number of grants, and the amount of grant funding received." ;
+            oa:prefix " with top-ranking institutions. " ;
+            oa:suffix "\n\n        \n                \n    "
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/rJA6mF4VEe6zCLO0i-c_sg>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Benefits", "PID Use Cases" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Use Case"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://popjournal.ca/issue03/goddard> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "They can also much more easily see whether researchers have met mandated obligations for open access publishing and open data sharing." ;
+            oa:prefix "heir various granting programs. " ;
+            oa:suffix "\nUniversities are increasingly a"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/GZFGEF4VEe6xClvFcBddnA>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Benefits", "PID Use Cases" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Use Case"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://popjournal.ca/issue03/goddard> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "The global knowledge graph created by the interlinking of PIDs can help funders to much more easily identify the publications, patents, collaborations, and open knowledge resources that are generated through their various granting programs." ;
+            oa:prefix " agencies and oversight boards. " ;
+            oa:suffix " They can also much more easily "
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/7qA6Vl4UEe6y_hPf7OkKeA>
+    a oa:Annotation ;
+    dct:subject "" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Benefits to Institutions"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://popjournal.ca/issue03/goddard> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "benefit from efficiencies" ;
+            oa:prefix " and universities also stand to " ;
+            oa:suffix " gained by automatic information"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/kKYQnF4UEe6V5yuOIrUBiQ>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Benefits" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Time-saving: reduction in administrative burden"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://popjournal.ca/issue03/goddard> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "Benefits to Researchers" ;
+            oa:prefix " organizations, and publishers.\n" ;
+            oa:suffix "\nOne of the most common complain"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/8_htRF4TEe6edBtvkYh9Hg>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Features", "Resolvable" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Resolvability"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://popjournal.ca/issue03/goddard> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "identifiers will continue to resolve indefinitely." ;
+            oa:prefix "arily have to ensure that those " ;
+            oa:suffix " Most identifiers will resolve t"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/mW6UZl4TEe6J9GMu67X3YQ>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Features", "Redundancy", "Availability" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Redundancy"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://popjournal.ca/issue03/goddard> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "All PID Registration Agencies must have highly redundant storage and hosting infrastructure in order to ensure that services are globally available 24-7" ;
+            oa:prefix "ations (Oguz and Wallace 2016).\n" ;
+            oa:suffix ". If we imagine using Persistent"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/Svpk0l4SEe6VePuFwjk-EA>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Features", "Persistence" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Persistent"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://popjournal.ca/issue03/goddard> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "Persistent" ;
+            oa:prefix " about the research enterprise.\n" ;
+            oa:suffix "\nThe final characteristic that i"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/Yc2TeFxVEe603mN2LFeqdw>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Entities", "PID Usage" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "PID - Context - schema.org"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://www.researchobject.org/ro-crate/1.1/context.jsonld> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "context" ;
+            oa:prefix "ublicdomain/zero/1.0/\"\n  },\n  \"@" ;
+            oa:suffix "\": {\n    \"3DModel\": \"http://sche"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/LC0_GlxMEe6z2ecJLKvKOQ>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Entities", "PID Usage" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "PID - outputs and publications"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://www.researchobject.org/ro-crate/1.1/contextual-entities.html> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "Publications via citation property" ;
+            oa:prefix "d.org/0000-0001-6121-5409\"\n}\n   " ;
+            oa:suffix "  To associate a publication wit"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/0lAlfFwwEe6ciOegkQftOQ>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Usage" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "PID - Contact Information"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://www.researchobject.org/ro-crate/1.1/contextual-entities.html> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "Contact information" ;
+            oa:prefix ",\n  \"name\": \"Peter Sefton\"\n}\n   " ;
+            oa:suffix "  A RO-Crate SHOULD have contact"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/o4B58lwtEe6uBM9hyBULiQ>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Entities", "PID Usage" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Organisations - PID"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://www.researchobject.org/ro-crate/1.1/contextual-entities.html> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "Organizations as values" ;
+            oa:prefix "nization (see example below).   " ;
+            oa:suffix "  An Organization SHOULD be the "
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/cie-klwtEe6dpc-ESjLz-Q>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Entities", "PID Usage" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Persons - PID"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://www.researchobject.org/ro-crate/1.1/contextual-entities.html> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "People" ;
+            oa:prefix "N-LD identifiers for details.   " ;
+            oa:suffix "  A core principle of Linked dat"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/b8iY8lOeEe6G0TM5-NxNLw>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Features", "Machine-Readable" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "{Machine-Readable}"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://popjournal.ca/issue03/goddard> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "Machine-Readable" ;
+            oa:prefix "e by both humans and computers.\n" ;
+            oa:suffix "\nThe third principle of linked d"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/shZViFOTEe6yOUs6KSI-Aw>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Features", "Globally Unique" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "{Globally Unique}"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://popjournal.ca/issue03/goddard> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "Globally Unique Names" ;
+            oa:prefix "ty of those URIs in perpetuity.\n" ;
+            oa:suffix "\nDuring a recent rankings and re"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/5ar62u2oEe2XR3dHFS3i1g>
+    a oa:Annotation ;
+    dct:subject "Protocol Independence", "Independence", "_FI_", "PID Features" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "{Protocol Independence}"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://datascience.codata.org/articles/10.5334/dsj-2017-013> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "Systems such as DOI can thus support resolution mechanisms that are likely to be able to maintain the resolution of identifiers regardless of changes in technology or to one particular system." ;
+            oa:prefix " addresses (URIs and URLs) are. " ;
+            oa:suffix "\nAs of today, with enough histor"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/trJkcFODEe6pfKdfVuUBzw>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Benefits" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "P1: Benefits of PIDs"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://zenodo.org/record/7100578> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "Brown, Josh, Jones, Phill, Meadows, Alice, & Murphy, Fiona. (2022). Incentives to invest in identifiers: A cost-benefit analysis of persistent identifiers in Australian research systems. Zenodo. https://doi.org/10.5281/zenodo.7100578" ;
+            oa:prefix "  \n  Cite as\n  \n    \n    \n      " ;
+            oa:suffix "\n\n      \n  \n\n\n      Loading...\n\n"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/4FdcFlLqEe6Wn4c0dKFcng>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Use Cases", "PID Entities" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "PID Use Case Elements, entities"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://datacite.org/blog/launch-of-the-pid-network-project-understanding-metadata-workflows/> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "PIDs for research dataPIDs for instrumentsPIDs for academic eventsPIDs for cultural objects and their contextsPIDs for organizations and projectsPIDs for researchers and contributorsPIDs for physical objectsPIDs for open-access publishing services and current research information systems (CRIS)PIDs for softwarePIDs for text publications" ;
+            oa:prefix "g ten types of PIDs are covered:" ;
+            oa:suffix "The project will organize ten ev"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/b2ovzFLEEe6wlkN2lBn6WA>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Benefits", "Reproducibility" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Reproducibility"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://www.researchgate.net/publication/323944495_Requirements_for_a_global_data_infrastructure_in_support_of_CMIP6> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "Although the DOIs assigned to relatively large aggregations of datasets are well suited for citation and acknowledgment pur-poses, they are not issued at fine enough granularity to meet the scientific imperative that published results should be traceableand verifiable" ;
+            oa:prefix "acking, provenance, and curation" ;
+            oa:suffix ". Furthermore, management of the"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/6nQYZFLDEe6trmuv5lO8RA>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Use Cases" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "PID Use Cases"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://www.researchgate.net/publication/323944495_Requirements_for_a_global_data_infrastructure_in_support_of_CMIP6> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "Persistent identifiers for acknowledgment and citation" ;
+            oa:prefix "location of the dataitself).5.1 " ;
+            oa:suffix "30Based on earlier phases of CMI"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/Qawp8lLCEe6l_RPGujIFAQ>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Benefits" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "PID Motivations"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://www.researchgate.net/publication/323944495_Requirements_for_a_global_data_infrastructure_in_support_of_CMIP6> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "ne key element is to generate a dataset-centric rather than system-centric focus, with an aim to making the infrastructure less prone to systemic failure." ;
+            oa:prefix "e purpose of assigning credit. O" ;
+            oa:suffix " With these overarching principl"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/L_sycFLCEe6kdn-3G1L9MQ>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Benefits" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "PID Motivations"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://www.researchgate.net/publication/323944495_Requirements_for_a_global_data_infrastructure_in_support_of_CMIP6> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "scientific reproducibility and accountability" ;
+            oa:prefix "quirements include the need for " ;
+            oa:suffix " alongside the need to record an"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/jbslTlK1Ee6z02fBa3KJBA>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Use Cases", "PID Benefits", "FAIR", "Reproducibility" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Reusability and reproducibility of research output"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://www.surf.nl/files/2022-03/towards-nl-pid-roadmap-20220225_0.pdf> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "To reuse and/or reproduce research it is desirable that researchoutput be available with sufficient context and details for bothhumans and machines to be able to interpret the data as described inthe FAIR principles" ;
+            oa:prefix "producibility of research output" ;
+            oa:suffix " (FAIR data principles).For rese"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/fYDrNFKzEe6Q7_N8aocwng>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Use Cases", "PID Benefits" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Registering and reporting research"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://www.surf.nl/files/2022-03/towards-nl-pid-roadmap-20220225_0.pdf> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "Registration of research output is necessary to report tofunders like NWO, ZonMW, SIA, etc. for monitoring andevaluation of research (e.g. according to SEP or BKOprotocols). Persistent identifiers can be applied to ease theadministrative burden. This results in better reporting,better information management and in the end betterresearch information." ;
+            oa:prefix "search outputColophonRegistering" ;
+            oa:suffix "Differences between sectorsWe ha"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/059ImlKyEe6jN9OX0zQb2A>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Use Cases" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "PID Use Cases"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://www.surf.nl/files/2022-03/towards-nl-pid-roadmap-20220225_0.pdf> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "1. Registration and reporting research2. Reusability and reproducibility of research3. Evaluation and recognition of research4. Grant application5. Researcher profiling6. Journal rankings" ;
+            oa:prefix "lowing usecases were considered:" ;
+            oa:suffix "Use cases 1 and 2 were selected "
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/1enHZFJoEe6tj59sjuujoQ>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Use Cases", "PID Benefits" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "PID Use Cases"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://www.rd-alliance.org/system/files/UNITED%20KINGDOM%20Case%20Study%20-%20National%20PID%20Strategies.pdf> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "STAGE Description PIDs Benefits" ;
+            oa:prefix "is shown in the following table:" ;
+            oa:suffix "GRANTAPPLICATIONResearchers and "
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/APYSEFJKEe6ObJM-fmulUQ>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Use Cases" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "PID Use Cases"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://www.rd-alliance.org/system/files/NEW%20ZEALAND%20Case%20Study%20-%20National%20PID%20Strategies.docx.pdf> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "Deduplication of researchersLinkage with awardsAuthoritative attribution of affiliationand worksORCID iD RecommendedIdentification of datasets, software andother types of research outputsDataCite DOI RecommendedIdentification of organisations GRID/ROR RecommendedIdentification of organisations inNZRISNZBN Required for data providers" ;
+            oa:prefix "ID type Recommended or required?" ;
+            oa:suffix "Case Study: NEW ZEALAND Page 5 o"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/F1yfqFJIEe6iO4dJoLlq9A>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Use Cases" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "PID Use Cases"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://www.rd-alliance.org/system/files/GERMANY%20Case%20Study%20-%20National%20PID%20Strategies.docx.pdf> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "Function PID type (Examples:) Recommended or required?" ;
+            oa:prefix " and/or strategy is CrossRef DOI" ;
+            oa:suffix "Research data DataCite DOI, URN "
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/1H_A1FJHEe6CBmOHJ8NuGA>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Adoption Metrics" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "PID Use Cases"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://www.rd-alliance.org/system/files/GERMANY%20Case%20Study%20-%20National%20PID%20Strategies.docx.pdf> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "The progress and impact of the project will be measured and monitored through the collection ofquantitative indicators. The different systems of the project partners as well as ORCID Inc. andROR will be queried. If possible, indicators for all 10 PID use cases should be measured. Theseinclude for example the following indicators:● Number of registered DataCite DOIs by scientific institutions in Germany.● Number of registered DataCite-DOIs that have a link to further resources via arelated-IDentifier relationship.● Number of ROR implementations at scientific institutions in Germany.● Number of GND records that have an ORCID iD or a ROR ID.● Etc." ;
+            oa:prefix "eviewand/or monitoring processes" ;
+            oa:suffix "How the impact of the roadmap ca"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/4CAgEFI8Ee65ravJVPNKGQ>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Use Cases" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "PID Use Cases"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://www.rd-alliance.org/system/files/KOREA%20Case%20Study%20-%20National%20PID%20Strategies.docx.pdf> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "Key features● KISTI’s mission is to curate collect, consolidate, and provide scientific information toKorean researchers and institutions. It includes but is not limited to.■ Curating Korean R&D outputs. Curate them higher state of identification for bettercuration, tracking research impact, analysing research outcomes.■ DOI RA management. Issuing DOIs to Korean research outputs, Intellectualproperties, research data■ Support Korean societies to stimulate better visibilities of their journal articlesaround the world.■ Collaborate for better curation (identification and interlinking) with domestic andglobal scientific information management institutions, publishers and identifiermanaging agencies" ;
+            oa:prefix "s remitKorean research articles." ;
+            oa:suffix ".Key infrastructureList and desc"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/guYFelIbEe6VRIvLTMD4jA>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Schema" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "PID Use Cases"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://www.rd-alliance.org/system/files/FINLAND%20Case%20Study%20-%20National%20PID%20Strategies.pdf> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "Name of infrastructure Key purpose List of integrated PIDsFairdata.fi Research data publication,metadata hub andpreservation serviceDOI, URN, ORCID (updaResearch.fi National research data hub. Current draft:ADSbibcode - AstrophysicsData System -Bibliographic ReferenceCode (en)ARK - Archival ResourceKey (en)arXiv - arXiv identifierscheme (en)BusinessID - Y-tunnus (fi)(en)Crossref_funders -Crossref Funder Registry(en)DOI - Digital ObjectIdentifier (en)Case Study: FINLAND Page 3 of 6" ;
+            oa:prefix "nfrastructuresKey infrastructure" ;
+            oa:suffix "EAN13 - The 13-digitInternationa"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/jsNzLlIVEe6xylsqh3uCdA>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Use Cases" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "PID Use Cases"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://www.rd-alliance.org/system/files/CZECH%20REPUBLIC%20Case%20Study%20-%20National%20PID%20Strategies.pdf> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "Name of infrastructure Key purpose List ofintegratedPIDse-infra This large infrastructure will build the NationalRepository Platform in the upcoming years. Thatshould greatly facilitate adoption of PIDs.TBDNational CRIS - IS VaVaI(R&D Information System)National research information system. We planon working with Research, Development andInnovation Council (in charge of IS VaVaI) onintegrating global PIDs into their submissionprocesses as required. Nowadays it uses mostlylocal identifiers.TBDInstitutional CRIS systems Various institutional CRIS systems at CzechRPOs. OBD (Personal Bibliographic Database)application is an outstanding case of aninstitutional CRIS system in the Czech Republicdeveloped locally by a Czech company DERS.An ORCID integration for OBD is currently indevelopment.TBD, OBDORCID inprocessInstitutional or subjectrepositoriesThere are several repositories in the Czechrepublic collecting different objects, some arealready using PIDs but there is still enough roomto improve and really integrate those PIDs, notonly allow their evidence.Handle,DOI,maybeotherMajor research funders Grant application processes TBDLocal publishers Content submission processes TBD" ;
+            oa:prefix "tudy: CZECH REPUBLIC Page 4 of 6" ;
+            oa:suffix "PIDsList which functions and PID"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/WwdROFITEe6e29_XEYealQ>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Stakeholders" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "PID Stakeholders and Target Groups"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://www.rd-alliance.org/system/files/CZECH%20REPUBLIC%20Case%20Study%20-%20National%20PID%20Strategies.pdf> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "TARGET INSTITUTIONS:● Public research performing organisations (RPOs): Higher Education Institutions andResearch organizations● Research funding organizations (RFOs): Ministry of Education, Youth and Sports, CzechScience Foundation, Technology Agency of the Czech Republic etc.● Policymakers: Ministry of Education, Youth and Sports; Research, Development andInnovation Council (R&D&I Council)● Libraries: National library, National Library of Technology, academic libraries● Publishers based in Czechia● Service providers, research infrastructuresTARGET GROUPS:● Researchers● Librarians● Open Science/Open Access managers/coordinators● CRIS system managers● Repository managers● Other research support positions, e.g. data stewards, data curators" ;
+            oa:prefix "trategy will primarily apply to:" ;
+            oa:suffix "DriversDescribe the drivers behi"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/UdH0UlISEe6YzBMMH7ilXw>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Use Cases" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "PID Use Cases"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://www.rd-alliance.org/system/files/CZECH%20REPUBLIC%20Case%20Study%20-%20National%20PID%20Strategies.pdf> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "Function PID type Recommended or required?" ;
+            oa:prefix " and/or strategy is CrossRef DOI" ;
+            oa:suffix "Identification of researchers OR"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/PFpvhFIQEe6cEstp9YCsPw>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Use Cases" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "PID - Vocabularies for Concepts and Things"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://www.rd-alliance.org/system/files/AUSTRALIA%20Case%20Study%20-%20National%20PID%20Strategies.pdf> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "ResearchVocabularies Australia" ;
+            oa:prefix "cluding Research DataAustralia, " ;
+            oa:suffix ",Research Link Australia,Researc"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/dr5OqFHJEe63OUMHdKVj7A>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Recommendations" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "PID Use Cases in the Netherlands"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://www.rd-alliance.org/system/files/NETHERLANDS%20Case%20Study%20-%20National%20PID%20Strategies.pdf> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "Function PID type Recommended or required?" ;
+            oa:prefix " and/or strategy is CrossRef DOI" ;
+            oa:suffix "Identification of researcher(s)f"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/TtWjdFHIEe6ibVvlTNZ2ow>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Use Cases" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "PID Use Cases in the Netherlands"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://www.rd-alliance.org/system/files/NETHERLANDS%20Case%20Study%20-%20National%20PID%20Strategies.pdf> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "1. Registration and reporting research2. Reusability and reproducibility of research3. Evaluation and recognition of research4. Grant application5. Researcher profiling6. Journal rankings" ;
+            oa:prefix "nd will be described one by one:" ;
+            oa:suffix "Case Study: NETHERLANDS Page 2 o"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/8crpelFhEe6HnX_RtkX8sg>
+    a oa:Annotation ;
+    dct:subject "_FI_", "PID Usage", "PID Stacks", "PID Use Cases" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "PID usage by country"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://www.rd-alliance.org/system/files/GUIDE%20and%20CHECKLIST%20Pathways%20to%20National%20PID%20Strategies%20(RDA%20WG%20Output)%20.pdf> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "PIDs comparison tableCase study Function PID typeFinland Researchers, persons ORCID; ISNIOrganisations VAT-number (not resolvableyet)RoRISNI___________________________________________________________________________________________________________________Pathways to National PID Strategies: Guide and Checklist to facilitate uptake and alignment Page 13 of 20" ;
+            oa:prefix "ISBN, RRID,ARK, Handle and more." ;
+            oa:suffix "PIC (not resolvable yet)SF-edu-I"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/aIR1bkfPEe6wkZ-NWwFN4g>
+    a oa:Annotation ;
+    dct:subject "Data Infrastructures and Environments - International", "FAIR, CARE, TRUST - Adoption, Implementation, and Deployment", "rda_graph", "Search and Discovery" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            ""
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://www.rd-alliance.org/sites/default/files/Generalist%20Repository%20Comparison%20Chart.pdf> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "Generalist repositorie" ;
+            oa:prefix "o preserve their research data. " ;
+            oa:suffix "s accept data regardlessof data "
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/zuqvfEWeEe6i8H_QmgF1EA>
+    a oa:Annotation ;
+    dct:subject "CURE-FAIR WG", "rda_graph" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Test for multiple annotations"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://zenodo.org/record/6797657> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "10 Things for Curating Reproducible and FAIR Research" ;
+            oa:prefix "ang, Qian\n      This document, \"" ;
+            oa:suffix ",\" describes the key issues of c"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/a4s20EKEEe695IPsMaL_hQ>
+    a oa:Annotation ;
+    dct:subject "FAIR Data Maturity Model WG", "FAIR for Research Software (FAIR4RS) WG", "FAIR for Virtual Research Environments WG", "FAIRsharing Registry: Connecting data policies, standards and databases RDA WG", "rda_graph" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "Annotated with RDA Tags: Working groups"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://zenodo.org/record/5537032> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "research data life cycle" ;
+            oa:prefix " data principles throughout the " ;
+            oa:suffix ". The FAIRsFAIR project runs fro"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/WoSDxikYEe6ifjfGIXT9BQ>
+    a oa:Annotation ;
+    dct:subject "PID Schema", "schemes", "Features" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "[Schemes]\n[Feature Support]"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://wiki.surfnet.nl/display/standards/info-eu-repo> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "Supported Schemes" ;
+            oa:prefix "ifier of a resource OpenAIREplus" ;
+            oa:suffix "SchemeDescriptionSchemeDescripti"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/prPMahrrEe67Q78YYtvmkg>
+    a oa:Annotation ;
+    dct:subject "GDPR", "Metadata", "Exceptions" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "[GDPR and Metadata]"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://gdpr-info.eu/art-9-gdpr/> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "processing relates to personal data which are manifestly made public by the data subject;" ;
+            oa:prefix "e consent of the data subjects;\n" ;
+            oa:suffix "\nprocessing is necessary for the"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/Sl26bv0fEe28KKt2JsklBQ>
+    a oa:Annotation ;
+    dct:subject "AI", "Artificial Intelligence", "Deep Learning" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "[29] AI - Deep Learning"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://medium.com/@marcellvollmer/how-to-make-it-simple-to-explain-ai-ml-dl-and-data-science-a49e54d54a12> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "Deep Learning (DL) A Technique for Implementing Machine LearningSubfield of ML that uses specialized techniques involving multi-layer (2+) artificial neural networksLayering allows cascaded learning and abstraction levels (e.g. line -> shape -> object -> scene)Computationally intensive enabled by clouds, GPUs, and specialized HW such as FPGAs, TPUs, etc." ;
+            oa:prefix "omputation runs or through usage" ;
+            oa:suffix "Data Science — Scientific method"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/G3XllP0cEe2voBuf27P0Nw>
+    a oa:Annotation ;
+    dct:subject "AI", "Artificial Intelligence", "History" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "[28] AI - precedents..."
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://en.wikiquote.org/wiki/Charles_Babbage> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "The object of the present volume is to point out the effects and the advantages which arise from the use of tools and machines ;—to endeavour to classify their modes of action ;—and to trace both the causes and the consequences of applying machinery to supersede the skill and power of the human arm." ;
+            oa:prefix "hinery and Manufactures (1832)\n\n" ;
+            oa:suffix "\nPreface\nThe errors which arise "
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/mI8n5PxTEe2cp2M4j_avuw>
+    a oa:Annotation ;
+    dct:subject "AI", "Artificial Intelligence", "alignment" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "[25] AI - Alignment"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://openai.com/product/gpt-4> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "Safety & alignment" ;
+            oa:prefix "3.5 on our internal evaluations." ;
+            oa:suffix "Training with human feedbackWe i"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/knIgUvxREe2j2v_gI9-SBQ>
+    a oa:Annotation ;
+    dct:subject "AI", "Artificial Intelligence", "Subtle Bias", "Training Corpus" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "[24] AI - Bias in Training Materials"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://ourworldindata.org/books> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "A book is defined as a published title with more than 49 pages." ;
+            oa:prefix "s per half century, 1475 to 1775" ;
+            oa:suffix "Add country or regionAll togethe"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/362ibPxPEe2UP98bUW3svQ>
+    a oa:Annotation ;
+    dct:subject "AI", "Artificial Intelligence", "Sills Erosion" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "[21] AI - Skills Erosion"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://www.notepage.net/mobile/is-predictive-texting-harmful.html> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "Epidemiologist Michael Abramson, who led the research, found that the participants who texted more often tended to work faster but score lower on the tests." ;
+            oa:prefix "nt was administered an IQ test. " ;
+            oa:suffix "\n\nThis heightened tendency to ac"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/_TtwdPxLEe2wlB9MnWZdfA>
+    a oa:Annotation ;
+    dct:subject "AI", "Artificial Intelligence", "Nuances", "Subtle Bias" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "[21] AI Nuances"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://www.technologyreview.com/2020/12/04/1013294/google-ai-ethics-research-paper-forced-out-timnit-gebru/> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "An AI model taught to view racist language as normal is obviously bad. The researchers, though, point out a couple of more subtle problems. One is that shifts in language play an important role in social change; the MeToo and Black Lives Matter movements, for example, have tried to establish a new anti-sexist and anti-racist vocabulary. An AI model trained on vast swaths of the internet won’t be attuned to the nuances of this vocabulary and won’t produce or interpret language in line with these new cultural norms.  It will also fail to capture the language and the norms of countries and peoples that have less access to the internet and thus a smaller linguistic footprint online. The result is that AI-generated language will be homogenized, reflecting the practices of the richest countries and communities." ;
+            oa:prefix " ends up in the training data.  " ;
+            oa:suffix "  Moreover, because the training"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/BVqJLPxKEe2ZVRMiHMgC9A>
+    a oa:Annotation ;
+    dct:subject "AI", "Artificial Intelligence", "alignment" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "[20] AI - Alignment Goals"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://serokell.io/blog/what-is-ai-alignment> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "According to him, there are several goals connected to AI alignment that need to be addressed:" ;
+            oa:prefix "hares the same values as we do.\n" ;
+            oa:suffix "\n\nEnsure that intelligent system"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/8uTOmPxDEe2wRy8wBERBAQ>
+    a oa:Annotation ;
+    dct:subject "AI", "Artificial Intelligence", "Legal Response" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "[19] AI - Legal Response"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://cointelegraph.com/news/european-union-pushes-forward-with-first-ai-framework-law-decoded-april-24-may-1> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "The AI developers came under intense scrutiny in Europe recently, with Italy being the first Western nation to temporarily ban ChatGPT" ;
+            oa:prefix "ighted materials in AI training." ;
+            oa:suffix ". Last week regulators in German"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/DyIFMPvgEe2LP0_0QLG0og>
+    a oa:Annotation ;
+    dct:subject "AI", "Artificial Intelligence" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "[18] AI - Increased sophistication"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://www.visualcapitalist.com/how-smart-is-chatgpt/> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "The following table lists the results that we visualized in the graphic." ;
+            oa:prefix "igher than 60% of test-takers. \n" ;
+            oa:suffix " \n\n\n\nCategoryExamGPT-4\nPercentil"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/i_-XSvveEe2itQuLxdC8Dw>
+    a oa:Annotation ;
+    dct:subject "" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "[3] AI - Risk Clasiification"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://artificialintelligenceact.eu/the-act/> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "A summary presentation on the Act by the European Commission can be downloaded here." ;
+            oa:prefix "an language, follow this link. \n" ;
+            oa:suffix " \n\t\t\t\n\t\t\t\n\t\t\t\t\n\t\t\t\t\n\t\t\t\n\t\t\t\t\n\t\t\t"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/CP690vvcEe2H0wPWhYPMbQ>
+    a oa:Annotation ;
+    dct:subject "" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "[17] AI- Features - Image Synthesis"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://www.visualcapitalist.com/generative-ai-explained-by-ai/> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "Images: Generative AI can create new images based on existing ones, such as creating a new portrait based on a person’s face or a new landscape based on existing scenery" ;
+            oa:prefix "ge of applications, including:\n\n" ;
+            oa:suffix "\nText: Generative AI can be used"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/fI1z_PvbEe2m_c-CYk4DyQ>
+    a oa:Annotation ;
+    dct:subject "" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "[14] AI Features - Provenance"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://blog.google/products/search/generative-ai-search/> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "To evaluate the information for yourself, you can also expand your view to see how the response is corroborated, and click to go deeper." ;
+            oa:prefix " these capabilities will appear." ;
+            oa:suffix "\n      \n    \n  \n\n  \n    \n      \n"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/RbnVPPvbEe2ajkOS23cG3w>
+    a oa:Annotation ;
+    dct:subject "" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "[14] AI - Summary"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://blog.google/products/search/generative-ai-search/> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "You’ll see an AI-powered snapshot of key information to consider, with links to dig deeper." ;
+            oa:prefix "e of that heavy lifting for you." ;
+            oa:suffix "\n      \n    \n  \n\n  \n    \n\n\n\n\n\n\n\n"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/9WGXJPvZEe28BGOGll2ndg>
+    a oa:Annotation ;
+    dct:subject "" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "[15] AI - Attitudes"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://www.visualcapitalist.com/visualizing-global-attitudes-towards-ai/> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "Netherlands33%$57,768" ;
+            oa:prefix "203\n\n\tUnited States35%$70,249\n\n\t" ;
+            oa:suffix "\n\n\tCanada32%$51,988\n\n\tFrance31%$"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/wHmb9vvZEe2TBUOXVrPasA>
+    a oa:Annotation ;
+    dct:subject "" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "[15] AI - Growth of Users"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://www.visualcapitalist.com/ranked-the-worlds-top-25-websites-in-2023/> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "17openai.com1.8Technology - Other" ;
+            oa:prefix "Networks\n\n\n\t16live.com2Email\n\n\n\t" ;
+            oa:suffix "\n\n\n\t18reddit.com1.7Social Media "
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/XAFc4PvZEe2i_xOdD_9dng>
+    a oa:Annotation ;
+    dct:subject "" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "[10] AI - Influencing Concerns"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://openai.com/research/forecasting-misuse> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "Actors: Language models could drive down the cost of running influence operations, placing them within reach of new actors and actor types. Likewise, propagandists-for-hire that automate production of text may gain new competitive advantages.Behavior: Influence operations with language models will become easier to scale, and tactics that are currently expensive (e.g., generating personalized content) may become cheaper. Language models may also enable new tactics to emerge—like real-time content generation in chatbots.Content: Text creation tools powered by language models may generate more impactful or persuasive messaging compared to propagandists, especially those who lack requisite linguistic or cultural knowledge of their target. They may also make influence operations less discoverable, since they repeatedly create new content without needing to resort to copy-pasting and other noticeable time-saving behaviors." ;
+            oa:prefix "tial to impact all three facets:" ;
+            oa:suffix "Our bottom-line judgment is that"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/BLESgvvZEe2NTqsllMRqDA>
+    a oa:Annotation ;
+    dct:subject "" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "[13] AI Features - Provenance"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://blogs.microsoft.com/blog/2023/02/07/reinventing-search-with-a-new-ai-powered-microsoft-bing-and-edge-your-copilot-for-the-web/> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "The new Bing also cites all its sources, so you’re able to see links to the web content it references." ;
+            oa:prefix "create a quiz for trivia night. " ;
+            oa:suffix "\nNew Microsoft Edge experience. "
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/MbI8vPvYEe2NS08abGCILg>
+    a oa:Annotation ;
+    dct:subject "" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "[13] AI Features - Refinement"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://blogs.microsoft.com/blog/2023/02/07/reinventing-search-with-a-new-ai-powered-microsoft-bing-and-edge-your-copilot-for-the-web/> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "empowers you to refine your search until you get the complete answer you are looking for by asking for more details, clarity and ideas – with links available so you can immediately act on your decisions." ;
+            oa:prefix "ctive chat. The chat experience " ;
+            oa:suffix "\nA creative spark. There are tim"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/f8V5KPvYEe2Hw9euOxGYcw>
+    a oa:Annotation ;
+    dct:subject "" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "[13] AI Features - Summaries"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://blogs.microsoft.com/blog/2023/02/07/reinventing-search-with-a-new-ai-powered-microsoft-bing-and-edge-your-copilot-for-the-web/> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "reviews results from across the web to find and summarize the answer you’re looking for." ;
+            oa:prefix "nt them.\nComplete answers. Bing " ;
+            oa:suffix " For example, you can get detail"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/2XXYMO3UEe2y9Y_yfGFibA>
+    a oa:Annotation ;
+    dct:subject "Dynamic", "Metadata", "Mutable", "PID Schema", "Functionality" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "{Dynamic}"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://datascience.codata.org/articles/10.5334/dsj-2017-013> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "Editable metadata – identifiers’ metadata must be able to be edited in order to allow their owners to update details of the thing they are referring to, such as its location, as they will inevitably change." ;
+            oa:prefix "estricted to particular agent;\n\n" ;
+            oa:suffix "\n\n\n\nStoring identifiers\nIdentifi"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/dFS6cO3UEe29gNMIvS0lvQ>
+    a oa:Annotation ;
+    dct:subject "Ownership", "Single Agent", "Management", "Functionality" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "{Single Agent}"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://datascience.codata.org/articles/10.5334/dsj-2017-013> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "Ownership – identifiers created must be able to have their management restricted to particular agent;" ;
+            oa:prefix "ly globally, to avoid clashes;\n\n" ;
+            oa:suffix "\n\nEditable metadata – identifier"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/GR3RRu3UEe29fr92rySr8w>
+    a oa:Annotation ;
+    dct:subject "UTF-8", "Technical", "Independence", "Functionality", "ASCII Case Folding" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "{UTF-8}\n{ASCII Case Folding}"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://datascience.codata.org/articles/10.5334/dsj-2017-013> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "articulates requirements for readability sating that identifiers must be:\n\nAny printable characters from the Universal Character Set of ISO/IEC 10646 (ISO 2012):UTF-8 encoding is required;\n\nCase insensitive:Only ASCII case folding is allowed." ;
+            oa:prefix " ‘Handle Syntax’ section) which " ;
+            oa:suffix "\n\n\nWe extend the HTTP and Handle"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/Ff6IKO2pEe24_CsbP792AQ>
+    a oa:Annotation ;
+    dct:subject "Protocol Independence", "Independence" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "{Protocol Independence}"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://datascience.codata.org/articles/10.5334/dsj-2017-013> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "The reason for broadening them is that identifier resolution systems may be forced to change protocols over time and what is acceptable for one protocol may not be for another." ;
+            oa:prefix "r pattern matching identifiers. " ;
+            oa:suffix " LSIDs (OMG, 2004), which are ba"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/uZycZO2oEe2dnq9dKIxsrQ>
+    a oa:Annotation ;
+    dct:subject "Independence", "Functionality" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "{Independence}"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://datascience.codata.org/articles/10.5334/dsj-2017-013> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "Creating identifiers that are independent of any particular technology or organisation and are able to be unambiguously understood are well-known requirement for PID systems." ;
+            oa:prefix "hange\n\n\nIdentifier independence\n" ;
+            oa:suffix " The posit ‘Cool URIs’ was put f"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/WSP6bO2oEe2toUOPHEcTrg>
+    a oa:Annotation ;
+    dct:subject "Unique", "Functionality" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "{Unique}"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://datascience.codata.org/articles/10.5334/dsj-2017-013> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "Uniqueness – within some scope, not necessarily globally, to avoid clashes;" ;
+            oa:prefix " system also needs to ensure:\n\n\n" ;
+            oa:suffix "\n\nOwnership – identifiers create"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/tp7F7O2nEe2b9T8JrOFOdg>
+    a oa:Annotation ;
+    dct:subject "Record-keeping", "Competence", "Performance", "Administrative Capacity" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "{Record-keeping}"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://www.doi.org/the-identifier/resources/handbook/4_data_model> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "In addition, data model policy requires that RAs maintain a record of the date of allocation of a DOI name, and the identity of the registrant on whose behalf the DOI name was allocated." ;
+            oa:prefix "operability within the network. " ;
+            oa:suffix "\nThe DOI data model policy also "
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/MSDJCO2gEe2wDSOJP7dxqg>
+    a oa:Annotation ;
+    dct:subject "Competence", "Unambiguous Allocation", "Administrative Capacity", "Performance", "Interoperability Guarantee" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "{Competence}\n{Unambiguous Allocation}"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://www.doi.org/the-identifier/resources/handbook/4_data_model> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "The policy provides a simple test of an RA’s competence: the ability to make a DOI Kernel Declaration, which requires that the RA has an internal system which can support the unambiguous allocation of a DOI name, and is fundamentally sound enough to support interoperability within the network." ;
+            oa:prefix "names do not enter the network.\n" ;
+            oa:suffix " In addition, data model policy "
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/KSqnxO2fEe2kzFP9i6SGOw>
+    a oa:Annotation ;
+    dct:subject "Quality Assurance", "Value Addition", "Performance" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "{Quality Assurance}"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://www.doi.org/the-identifier/resources/handbook/8_registration_agencies> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "Designing and implementing specific operational processes for e.g. quality control of input data and output data;\nIntegrating the community into other DOI related activities and services." ;
+            oa:prefix "he DOI system to the community;\n" ;
+            oa:suffix "\n\nThe following is a summary of "
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/4-2VXu2eEe2uJhtebwC1QQ>
+    a oa:Annotation ;
+    dct:subject "Data Typing", "Multple Resolution", "Performance", "Value Addition" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "{Data Typing}\n{Multiple Resolution}"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://www.doi.org/the-identifier/resources/factsheets/key-facts-on-digital-object-identifier-system> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "More sophisticated functionality available, e.g., multiple resolution, data typing" ;
+            oa:prefix "ction — a persistent identifier\n" ;
+            oa:suffix "\nInternational Standard: ISO 263"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/8a0Z8u2QEe2veJeqOMkGNg>
+    a oa:Annotation ;
+    dct:subject "Services", "Value Addition", "Performance" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "{Services}"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://www.doi.org/the-identifier/resources/handbook/8_registration_agencies> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "Providing applications, services, marketing, outreach, business cases etc. to introduce the DOI system to the community;\nDesigning and implementing specific operational processes for e.g. quality control of input data and output data;" ;
+            oa:prefix "on and advice to the community;\n" ;
+            oa:suffix "\nIntegrating the community into "
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/vIGBFO2QEe2yIFuxOKni8g>
+    a oa:Annotation ;
+    dct:subject "Community Advice", "Value Addition", "Performance" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "{Community Advice}"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://www.doi.org/the-identifier/resources/handbook/8_registration_agencies> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "Providing information and advice to the community" ;
+            oa:prefix "y of the following activities:\n\n" ;
+            oa:suffix ";\nProviding applications, servic"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/YclrJO2QEe2wtgPsecmltA>
+    a oa:Annotation ;
+    dct:subject "Fee-for-Service", "Sustainable Operational Revenue", "Revenue", "Sustainability" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "{Fee-for-Service}"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://www.doi.org/the-identifier/resources/handbook/8_registration_agencies> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "Registration Agencies must comply with the policies and technical standards established by the IDF, but are free to develop their own business model for running their businesses. There is no appropriate “one size fits all” model; RAs may be for-profit or not-for-profit organisations. The costs of providing DOI registration may be included in the services offered by an RA provision and not separately distinguished from these. Examples of possible business models may involve explicit charging based on the number of prefixes allocated or the number of DOI names allocated; volume discounts, usage discounts, stepped charges, or any mix of these; indirect charging through inclusion of the basic registration functions in related value added services; and cross-subsidy from other sources." ;
+            oa:prefix "model for Registration Agencies\n" ;
+            oa:suffix "\nRegistration Agencies may choos"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/LvjpzO2QEe2ggwOjTf5lcA>
+    a oa:Annotation ;
+    dct:subject "Community", "Stakeholder", "Governance" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "{Community}"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://www.doi.org/the-identifier/resources/handbook/8_registration_agencies> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "Integrating the community into other DOI related activities and services" ;
+            oa:prefix " of input data and output data;\n" ;
+            oa:suffix ".\n\nThe following is a summary of"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/XzD4fu2PEe2ob0eqz_gCAw>
+    a oa:Annotation ;
+    dct:subject "Global", "Unique", "Functionality" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "{Global}"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://en.wikipedia.org/wiki/Uniform_Resource_Name> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "URNs are globally unique persistent identifiers assigned within defined namespaces so they will be available for a long period of time, even after the resource which they identify ceases to exist or becomes unavailable." ;
+            oa:prefix "(URI) that uses the urn scheme. " ;
+            oa:suffix "[1] URNs cannot be used to direc"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/CtHsou2PEe25m7NtHXswSg>
+    a oa:Annotation ;
+    dct:subject "Unambiguous Allocation", "Unique", "Functionality" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "{Unambiguous Allocation}"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://en.wikipedia.org/wiki/Uniform_Resource_Name> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "Approximately sixty formal URN namespace identifiers have been registered." ;
+            oa:prefix "d by RFC 8141.[1]\n\nFormal[edit]\n" ;
+            oa:suffix " These are namespaces where Inte"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/2Jz6iO2OEe2vdJPn03HeAA>
+    a oa:Annotation ;
+    dct:subject "Unique", "Functionality" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "{Unique}"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://en.wikipedia.org/wiki/Uniform_Resource_Name> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "In order to ensure the global uniqueness of URN namespaces, their identifiers (NIDs) are required to be registered with the IANA. Registered namespaces may be \"formal\" or \"informal\"." ;
+            oa:prefix "andardization.\nNamespaces[edit]\n" ;
+            oa:suffix " An exception to the registratio"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/s6B9GO2OEe2ltVsw6o3Mgg>
+    a oa:Annotation ;
+    dct:subject "Persistence", "Functionality" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "{Persistence}"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://en.wikipedia.org/wiki/Uniform_Resource_Name> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "A Uniform Resource Name (URN) is a Uniform Resource Identifier (URI) that uses the urn scheme. URNs are globally unique persistent identifiers assigned within defined namespaces so they will be available for a long period of time, even after the resource which they identify ceases to exist or becomes unavailable" ;
+            oa:prefix "uses, see URN (disambiguation).\n" ;
+            oa:suffix ".[1] URNs cannot be used to dire"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/dqJR3OyMEe2g4JOLBfdDxg>
+    a oa:Annotation ;
+    dct:subject "Persistence", "Functionality" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "{Persistence}"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://www.iso.org/obp/ui/> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "existence, and ability to be used in services outside the direct control of the issuing assigner, without a stated time limit" ;
+            oa:prefix "e referent \n(3.16)3.18persistent" ;
+            oa:suffix "3.19first classhaving an identit"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/JkJU8uyNEe2QMrPzqj_wKw>
+    a oa:Annotation ;
+    dct:subject "Unique", "Functionality" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "{Unique}"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://www.iso.org/obp/ui/> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "specification by a DOI name \n(3.2) of one and only one referent \n(3.16)" ;
+            oa:prefix " \n(3.2)3.17unique identification" ;
+            oa:suffix "3.18persistentexistence, and abi"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/UFjvYuyNEe2g4_u6UOgIJA>
+    a oa:Annotation ;
+    dct:subject "Resolvable", "Functionality" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "{Resolvable}"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://www.iso.org/obp/ui/> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "process of submitting a DOI name \n(3.2) to a network service and receiving in return one or more pieces of current information related to the identified object such as metadata or a location of the object or of metadata" ;
+            oa:prefix " interoperability.3.15resolution" ;
+            oa:suffix "Note 1 to entry: This can involv"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/l6hw9OyNEe2tXnt_RVolRw>
+    a oa:Annotation ;
+    dct:subject "Dynamic", "Functionality", "PID Schema", "Mutable" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "{Dynamic}"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://www.iso.org/obp/ui/> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "— dynamic updating of metadata, applications and services." ;
+            oa:prefix "f applications and services, and" ;
+            oa:suffix "The DOI system is designed to wo"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/Ev-QtuyOEe2QNW_rbaj_Vg>
+    a oa:Annotation ;
+    dct:subject "Platform Independence", "Independence", "Functionality" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "{Platform Independence}"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://www.iso.org/obp/ui/> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "— single management of data for multiple output formats (platform independence)," ;
+            oa:prefix "nagement of groups of DOI names," ;
+            oa:suffix "— class management of applicatio"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/x__EvuyNEe2LNP958KP-Bg>
+    a oa:Annotation ;
+    dct:subject "Interoperable", "Functionality", "PID Schema", "Kernel Metadata" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "{Interoperable}"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://www.iso.org/obp/ui/> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "— interoperability with other data from other sources," ;
+            oa:prefix "oved, rearranged, or bookmarked," ;
+            oa:suffix "— extensibility by adding new fe"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/Kspi_uyMEe2JzHtbGXV8rA>
+    a oa:Annotation ;
+    dct:subject "Persistence", "Functionality" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "{Persistence}"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://www.iso.org/obp/ui/> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "— persistence, if material is moved, rearranged, or bookmarked," ;
+            oa:prefix "t of functionalities, including:" ;
+            oa:suffix "— interoperability with other da"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/2Ta22u1KEe2V-PsqKCzhfg>
+    a oa:Annotation ;
+    dct:subject "Surplus", "Sustainability" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "{Surplus}"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://openscholarlyinfrastructure.org/> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "Goal to generate surplus – organisations which define sustainability based merely on recovering costs are brittle and stagnant. It is not enough to merely survive, it has to be able to adapt and change. To weather economic, social and technological volatility, they need financial resources beyond immediate operating costs." ;
+            oa:prefix "m building core infrastructure.\n" ;
+            oa:suffix "\nGoal to create contingency fund"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/CjvOIu0LEe27VevnGdvH9g>
+    a oa:Annotation ;
+    dct:subject "Cannot Lobby", "Governance", "Transparent" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "{Cannot Lobby}"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://openscholarlyinfrastructure.org/> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "Cannot lobby – the community, not infrastructure organisations, should collectively drive regulatory change. An infrastructure organisation’s role is to provide a base for others to work on and should depend on its community to support the creation of a legislative environment that affects it." ;
+            oa:prefix "e constraints of privacy laws).\n" ;
+            oa:suffix "\nLiving will – a powerful way to"
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/65LJMOyNEe2BAg-9R-agZA>
+    a oa:Annotation ;
+    dct:subject "Extensible" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "{Extensible}"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://www.iso.org/obp/ui/> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "— extensibility by adding new features and services through management of groups of DOI names," ;
+            oa:prefix "h other data from other sources," ;
+            oa:suffix "— single management of data for "
+        ]
+    ] .
+
+@prefix dct:  <http://purl.org/dc/terms/> .
+
+<https://hypothes.is/a/cbsb3OyLEe2LKXeBAKAeag>
+    a oa:Annotation ;
+    dct:subject "" ;
+    oa:hasBody [
+        a oa:TextualBody ;
+        rdf:value
+            "{Resolvable}"
+    ] ;
+
+    oa:hasTarget [
+        a oa:SpecificResource ;
+
+        oa:hasSource
+            <https://www.rfc-editor.org/rfc/rfc8141.html> ;
+
+        oa:hasSelector [
+            a oa:TextQuoteSelector ;
+            oa:exact
+                "this specification permits several other cases of URN\n   resolution as well as URNs for resources that do not involve\n   information retrieval systems.  This is true either individually for\n   particular URNs or (as defined below) collectively for entire URN\n   namespaces." ;
+            oa:prefix " a representation.\n\n   However, " ;
+            oa:suffix "\n\n   Consider a namespace of URN"
+        ]
+    ] .


### PR DESCRIPTION
Harvested 234 hypothes.is annotation(s) into `data/source/annotation.ttl` as Web Annotation (oa:) records.

Already present (skipped): 134
Not found: 0
Errors: 0